### PR TITLE
Fix illegal hardware instruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ set(BUDDY_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(BUDDY_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bin)
 set(BUDDY_EXAMPLES_DIR ${BUDDY_SOURCE_DIR}/examples)
 set(BUDDY_INCLUDE_DIR ${BUDDY_SOURCE_DIR}/include)
+set(BUDDY_OPT_ATTR avx512f CACHE STRING "Target Architecture.")
+message(STATUS "Configuring Target Architecture: ${BUDDY_OPT_ATTR}")
 
 set(BUILD_TESTS OFF CACHE BOOL "Build tests")
 

--- a/benchmarks/DeepLearning/Models/MobileNet-V2/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Models/MobileNet-V2/CMakeLists.txt
@@ -1,4 +1,3 @@
-set(BUDDY_OPT_ATTR avx512f)
 set(LLVM_MLIR_BINARY_DIR ${BUDDY_OPT_BUILD_DIR}/../llvm/build/bin)
 
 add_custom_command(OUTPUT mobilenet-default.o

--- a/benchmarks/DeepLearning/Ops/Conv2DNchwFchwOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/Conv2DNchwFchwOp/CMakeLists.txt
@@ -1,4 +1,3 @@
-set(BUDDY_OPT_ATTR avx512f)
 set(LLVM_MLIR_BINARY_DIR ${BUDDY_OPT_BUILD_DIR}/../llvm/build/bin)
 
 add_custom_command(OUTPUT conv-2d-nchw-fchw.o

--- a/benchmarks/DeepLearning/Ops/Conv2DNhwcHwcfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/Conv2DNhwcHwcfOp/CMakeLists.txt
@@ -1,4 +1,3 @@
-set(BUDDY_OPT_ATTR avx512f)
 set(LLVM_MLIR_BINARY_DIR ${BUDDY_OPT_BUILD_DIR}/../llvm/build/bin)
 
 add_custom_command(OUTPUT conv-2d-nhwc-hwcf.o

--- a/benchmarks/DeepLearning/Ops/DepthwiseConv2DNhwcHwcOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/DepthwiseConv2DNhwcHwcOp/CMakeLists.txt
@@ -1,4 +1,3 @@
-set(BUDDY_OPT_ATTR avx512f)
 set(LLVM_MLIR_BINARY_DIR ${BUDDY_OPT_BUILD_DIR}/../llvm/build/bin)
 
 add_custom_command(OUTPUT depthwise-conv-2d-nhwc-hwc.o

--- a/benchmarks/ImageProcessing/CMakeLists.txt
+++ b/benchmarks/ImageProcessing/CMakeLists.txt
@@ -1,9 +1,7 @@
 set(BUDDY_OPT_STRIP_MINING 256 CACHE STRING "Stride Size")
-set(BUDDY_OPT_ATTR avx512f CACHE STRING "Taget Architecture")
 set(LLVM_MLIR_BINARY_DIR ${BUDDY_OPT_BUILD_DIR}/../llvm/build/bin)
 
 message(STATUS "Configuring Stride Size: ${BUDDY_OPT_STRIP_MINING}")
-message(STATUS "Configuring Taget Architecture: ${BUDDY_OPT_ATTR}")
 
 #-------------------------------------------------------------------------------
 # MLIR Linalg Dialect Conv2D Operation + CB Algorithm


### PR DESCRIPTION
Fix "illegal hardware instruction" error when building with -DBUDDY_OPT_ATTR=avx2.