### PR TITLE
Add support for dynamic IP benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,19 @@ Run the image processing benchmark:
 | `-DBUDDY_OPT_ATTR`  | avx512f  |
 | `-DBUDDY_OPT_TRIPLE`  | x86_64-unknown-linux-gnu  |
 
-*Note: Please replace the `/PATH/TO/*` with your local path.*
+*Note:*
 
+*1. Please replace the `/PATH/TO/*` with your local path.*
+
+*2. For running executable :*
+
+*i. Please replace `<image path>` with path of the image which is to be used for*
+*benchmarking.*
+
+*ii. Please replace `<kernel name>` with name of the kernel which is to be used for*
+*benchmarking as specifed in `include/ImageProcessing/Kernels.h`.*
+
+Ex. `./image-processing-benchmark ../../benchmarks/ImageProcessing/Images/YuTu.png laplacianKernelAlign`
 ```
 $ cd buddy-benchmark
 $ mkdir build && cd build
@@ -40,7 +51,7 @@ $ cmake -G Ninja .. \
     -DOpenCV_DIR=/PATH/TO/OPENCV/BUILD/ \
     -DBUDDY_OPT_BUILD_DIR=/PATH/TO/BUDDY-MLIR/BUILD/
 $ ninja image-processing-benchmark
-$ cd bin && ./image-processing-benchmark
+$ cd bin && ./image-processing-benchmark <image path> <kernel name>
 ```
 
 ## Deep Learning Benchmark

--- a/benchmarks/ImageProcessing/Conv2DBenchmark.cpp
+++ b/benchmarks/ImageProcessing/Conv2DBenchmark.cpp
@@ -47,11 +47,10 @@ intptr_t sizesInputConv2D[2];
 intptr_t sizesKernelConv2D[2];
 intptr_t sizesOutputConv2D[2];
 
-void initializeBM_Conv2D_Buddy(int argc, char** argv)
-{
+void initializeBM_Conv2D_Buddy(int argc, char **argv) {
   inputImageConv2D = imread(argv[1], IMREAD_GRAYSCALE);
-  kernelConv2DMat = Mat(
-    get<1>(kernelMap[argv[2]]), get<2>(kernelMap[argv[2]]), CV_32FC1, get<0>(kernelMap[argv[2]]));
+  kernelConv2DMat = Mat(get<1>(kernelMap[argv[2]]), get<2>(kernelMap[argv[2]]),
+                        CV_32FC1, get<0>(kernelMap[argv[2]]));
 
   kernelRowsConv2D = kernelConv2DMat.rows;
   kernelColsConv2D = kernelConv2DMat.cols;

--- a/benchmarks/ImageProcessing/Corr2DBenchmark.cpp
+++ b/benchmarks/ImageProcessing/Corr2DBenchmark.cpp
@@ -38,7 +38,7 @@ void _mlir_ciface_corr_2d(MemRef<float, 2> *inputCorr2D,
 Mat inputImageCorr2D, kernelCorr2DMat;
 
 // Define the kernel size.
-int kernelRowsCorr2D, kernelColsCorr2D; 
+int kernelRowsCorr2D, kernelColsCorr2D;
 
 // Define the output size.
 int outputRowsCorr2D, outputColsCorr2D;
@@ -48,11 +48,10 @@ intptr_t sizesInputCorr2D[2];
 intptr_t sizesKernelCorr2D[2];
 intptr_t sizesOutputCorr2D[2];
 
-void initializeBM_Corr2D_Buddy(int argc, char** argv)
-{
+void initializeBM_Corr2D_Buddy(int argc, char **argv) {
   inputImageCorr2D = imread(argv[1], IMREAD_GRAYSCALE);
-  kernelCorr2DMat = Mat(
-    get<1>(kernelMap[argv[2]]), get<2>(kernelMap[argv[2]]), CV_32FC1, get<0>(kernelMap[argv[2]]));
+  kernelCorr2DMat = Mat(get<1>(kernelMap[argv[2]]), get<2>(kernelMap[argv[2]]),
+                        CV_32FC1, get<0>(kernelMap[argv[2]]));
 
   kernelRowsCorr2D = kernelCorr2DMat.rows;
   kernelColsCorr2D = kernelCorr2DMat.cols;

--- a/benchmarks/ImageProcessing/Filter2DBenchmark.cpp
+++ b/benchmarks/ImageProcessing/Filter2DBenchmark.cpp
@@ -28,12 +28,11 @@ using namespace std;
 // Declare input image, kernel and output image.
 Mat inputImageFilter2D, kernelFilter2D, outputFilter2D;
 
-void initializeBM_Filter2D_OpenCV(int argc, char** argv)
-{
+void initializeBM_Filter2D_OpenCV(int argc, char **argv) {
   inputImageFilter2D = imread(argv[1], IMREAD_GRAYSCALE);
 
-  kernelFilter2D = Mat(
-    get<1>(kernelMap[argv[2]]), get<2>(kernelMap[argv[2]]), CV_32FC1, get<0>(kernelMap[argv[2]]));
+  kernelFilter2D = Mat(get<1>(kernelMap[argv[2]]), get<2>(kernelMap[argv[2]]),
+                       CV_32FC1, get<0>(kernelMap[argv[2]]));
 }
 
 // Benchmarking function.

--- a/benchmarks/ImageProcessing/Filter2DBenchmark.cpp
+++ b/benchmarks/ImageProcessing/Filter2DBenchmark.cpp
@@ -25,13 +25,16 @@
 using namespace cv;
 using namespace std;
 
-// Read input image and specify kernel.
-Mat inputImageFilter2D = imread(
-    "../../benchmarks/ImageProcessing/Images/YuTu.png", IMREAD_GRAYSCALE);
-Mat kernelFilter2D = Mat(3, 3, CV_32FC1, laplacianKernelAlign);
+// Declare input image, kernel and output image.
+Mat inputImageFilter2D, kernelFilter2D, outputFilter2D;
 
-// Declare output image.
-Mat outputFilter2D;
+void initializeBM_Filter2D_OpenCV(int argc, char** argv)
+{
+  inputImageFilter2D = imread(argv[1], IMREAD_GRAYSCALE);
+
+  kernelFilter2D = Mat(
+    get<1>(kernelMap[argv[2]]), get<2>(kernelMap[argv[2]]), CV_32FC1, get<0>(kernelMap[argv[2]]));
+}
 
 // Benchmarking function.
 static void BM_Filter2D_OpenCV(benchmark::State &state) {

--- a/benchmarks/ImageProcessing/Main.cpp
+++ b/benchmarks/ImageProcessing/Main.cpp
@@ -20,21 +20,24 @@
 
 #include <benchmark/benchmark.h>
 
-void initializeBM_Conv2D_Buddy(int, char**);
-void initializeBM_Corr2D_Buddy(int, char**);
-void initializeBM_Filter2D_OpenCV(int, char**);
+void initializeBM_Conv2D_Buddy(int, char **);
+void initializeBM_Corr2D_Buddy(int, char **);
+void initializeBM_Filter2D_OpenCV(int, char **);
 
 void generateResultConv2D();
 void generateResultCorr2D();
 
 // Run benchmarks.
 int main(int argc, char **argv) {
-  if (argc != 3)
-  {
-    throw std::invalid_argument("Wrong format of command line arguments.\n"
-    "Correct format is ./image-processing-benchmark <image path> <kernel name>\n where "
-    "image path provides path of the image to be processed and kernel name denotes the name "
-    "of desired kernel as specified in include/ImageProcessing/Kernels.h\n");
+  if (argc != 3) {
+    throw std::invalid_argument(
+        "Wrong format of command line arguments.\n"
+        "Correct format is ./image-processing-benchmark <image path> <kernel "
+        "name>\n where "
+        "image path provides path of the image to be processed and kernel name "
+        "denotes the name "
+        "of desired kernel as specified in "
+        "include/ImageProcessing/Kernels.h\n");
   }
 
   initializeBM_Conv2D_Buddy(argc, argv);

--- a/benchmarks/ImageProcessing/Main.cpp
+++ b/benchmarks/ImageProcessing/Main.cpp
@@ -20,11 +20,27 @@
 
 #include <benchmark/benchmark.h>
 
+void initializeBM_Conv2D_Buddy(int, char**);
+void initializeBM_Corr2D_Buddy(int, char**);
+void initializeBM_Filter2D_OpenCV(int, char**);
+
 void generateResultConv2D();
 void generateResultCorr2D();
 
 // Run benchmarks.
 int main(int argc, char **argv) {
+  if (argc != 3)
+  {
+    throw std::invalid_argument("Wrong format of command line arguments.\n"
+    "Correct format is ./image-processing-benchmark <image path> <kernel name>\n where "
+    "image path provides path of the image to be processed and kernel name denotes the name "
+    "of desired kernel as specified in include/ImageProcessing/Kernels.h\n");
+  }
+
+  initializeBM_Conv2D_Buddy(argc, argv);
+  initializeBM_Corr2D_Buddy(argc, argv);
+  initializeBM_Filter2D_OpenCV(argc, argv);
+
   ::benchmark::Initialize(&argc, argv);
   ::benchmark::RunSpecifiedBenchmarks();
   // Generate result image.

--- a/include/ImageProcessing/Kernels.h
+++ b/include/ImageProcessing/Kernels.h
@@ -22,6 +22,8 @@
 #define IMAGE_PROCESSING_KERNELS
 
 // clang-format off
+#include <string>
+#include <map>
 
 static float prewittKernelAlign[9] = {-1, 0, 1, -1, 0, 1, -1, 0, 1};
 static int prewittKernelRows = 3;
@@ -72,6 +74,16 @@ static float logKernelAlign[25] = {0, 0, 1, 0, 0,
                                    0, 0, 1, 0, 0};
 static int logKernelRows = 5;
 static int logKernelCols = 5;
+
+static std::map<std::string, std::tuple<float*, int, int>> kernelMap = {
+    {"prewittKernelAlign", {prewittKernelAlign, prewittKernelRows, prewittKernelCols}},
+    {"sobel3x3KernelAlign", {sobel3x3KernelAlign, sobel3x3KernelRows, sobel3x3KernelCols}},
+    {"sobel5x5KernelAlign", {sobel5x5KernelAlign, sobel5x5KernelRows, sobel5x5KernelCols}},
+    {"sobel7x7KernelAlign", {sobel7x7KernelAlign, sobel7x7KernelRows, sobel7x7KernelCols}},
+    {"sobel9x9KernelAlign", {sobel9x9KernelAlign, sobel9x9KernelRows, sobel9x9KernelCols}},
+    {"laplacianKernelAlign", {laplacianKernelAlign, laplacianKernelRows, laplacianKernelCols}},
+    {"logKernelAlign", {logKernelAlign, logKernelRows, logKernelCols}}
+};
 
 // clang-format on
 


### PR DESCRIPTION
Current IP benchmark files do not support processing of different images and kernels without changing the source files. This PR intends to add support for it so that user can generate benchmarks for different images using different kernels right from the command line.