### PR TITLE
Add support for testing DIP dialect's 2D correlation op with OpenCV

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,21 @@ $ cmake --build . --
 $ ninja test
 ```
 
+For tests related to DIP dialect : 
+
+```
+$ cd buddy-benchmark
+$ mkdir build && cd build
+$ cmake -G Ninja .. \
+    -DIMAGE_PROCESSING_BENCHMARKS=ON \
+    -DDEEP_LEARNING_BENCHMARKS=ON \
+    -DBUILD_TESTS=ON \
+    -DOpenCV_DIR=/path/to/opencv/build/ \
+    -DBUDDY_OPT_BUILD_DIR=/path/to/buddy-mlir/build/ \
+    -DBUDDY_OPT_STRIP_MINING=<strip mining size, default: 256> \
+    -DBUDDY_OPT_ATTR=<ISA vector extension, default: avx512f>
+$ ninja DIPCorr2DTest
+$ cd bin && ./DIPCorr2DTest <image path>
+```
+
+where `<image path>` is the path of image used as first operand during 2D Correlation.

--- a/tests/UnitTests/CMakeLists.txt
+++ b/tests/UnitTests/CMakeLists.txt
@@ -11,3 +11,5 @@ add_dependencies(test-container Container)
 
 include(GoogleTest)
 gtest_discover_tests(test-container)
+
+add_subdirectory(ImageProcessing)

--- a/tests/UnitTests/ImageProcessing/CMakeLists.txt
+++ b/tests/UnitTests/ImageProcessing/CMakeLists.txt
@@ -1,0 +1,5 @@
+find_package(OpenCV REQUIRED CONFIG)
+include_directories(${OpenCV_INCLUDE_DIRS})
+
+add_executable(DIPCorr2DTest DIPCorr2DTest.cpp)
+target_link_libraries(DIPCorr2DTest ${OpenCV_LIBS} Corr2D Container PNGImage)

--- a/tests/UnitTests/ImageProcessing/DIPCorr2DTest.cpp
+++ b/tests/UnitTests/ImageProcessing/DIPCorr2DTest.cpp
@@ -1,0 +1,90 @@
+#include "../../../include/ImageProcessing/Kernels.h"
+#include "Utils/Container.h"
+
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/opencv.hpp>
+
+#include <iostream>
+
+using namespace cv;
+using namespace std;
+
+// Declare the Corr2D C interface.
+extern "C" {
+void _mlir_ciface_corr_2d(MemRef<float, 2> *input, MemRef<float, 2> *kernel,
+                          MemRef<float, 2> *output, unsigned int centerX,
+                          unsigned int centerY, int boundaryOption);
+}
+
+bool equalImages(const Mat &img1, const Mat &img2)
+{
+  if (img1.rows != img2.rows || img1.cols != img2.cols) {
+    std::cout << "Produced outputs by DIP and OpenCV differ. Image dimensions are not equal\n";
+    return 0;
+  }
+
+  for (unsigned int y = 0; y < img1.rows; ++y)
+  {
+    for (unsigned int x = 0; x < img1.cols; ++x)
+    {
+      if (abs(img1.at<float>(x, y) - img2.at<float>(x, y)) > 10e-3)
+      {
+        std::cout << "Produced outputs by DIP and OpenCV differ.\n";
+        return 0;
+      }
+    }
+  }
+  return 1;
+}
+
+void testKernelImpl(const Mat& inputImage, unsigned int kernelRows, unsigned int kernelCols, float* kernelArray, 
+                unsigned int x, unsigned int y)
+{
+  // Define container sizes.
+  intptr_t sizesInput[2] = {inputImage.rows, inputImage.cols};
+  intptr_t sizesKernel[2] = {kernelRows, kernelCols};
+  intptr_t sizesOutput[2] = {inputImage.rows, inputImage.cols};
+
+  // Define input, kernel, and output.
+  MemRef<float, 2> input(inputImage, sizesInput);
+  MemRef<float, 2> kernel(kernelArray, sizesKernel);
+  MemRef<float, 2> output(sizesOutput);
+
+  for (int i = 0; i < inputImage.rows; i++)
+    for (int j = 0; j < inputImage.cols; j++)
+      output[i * inputImage.rows + j] = 0;
+
+  Mat kernel1 = Mat(kernelRows, kernelCols, CV_32FC1, kernelArray);
+  Mat opencvOutput;
+
+  _mlir_ciface_corr_2d(&input, &kernel, &output, x, y, 0);
+
+  filter2D(inputImage, opencvOutput, CV_32FC1, kernel1, cv::Point(x, y), 1.0,
+        cv::BORDER_REPLICATE);
+
+  // Define a cv::Mat with the output of corr_2d.
+  Mat dipOutput(inputImage.rows, inputImage.cols, CV_32FC1, output.getData());
+
+  if (!equalImages(dipOutput, opencvOutput))
+  {
+    std::cout << "Different images produced by OpenCV and DIP for kernel :\n" << kernel1 << "\n"
+        "when anchor point was : (" << x << ", " << y << ").\n";
+    return;
+  }
+}
+
+void testKernel(const Mat& inputImage, unsigned int kernelRows, unsigned int kernelCols, float* kernelArray)
+{
+  for (unsigned int y = 0; y < kernelRows; ++y)
+    for (unsigned int x = 0; x < kernelCols; ++x)
+      testKernelImpl(inputImage, kernelRows, kernelCols, kernelArray, x, y);
+}
+
+int main(int argc, char **argv)
+{
+  // Read input image
+  Mat inputImage = imread(argv[1], IMREAD_GRAYSCALE);
+
+  for (auto kernel : kernelMap)
+    testKernel(inputImage, get<1>(kernel.second), get<2>(kernel.second), get<0>(kernel.second));
+}

--- a/tests/UnitTests/ImageProcessing/DIPCorr2DTest.cpp
+++ b/tests/UnitTests/ImageProcessing/DIPCorr2DTest.cpp
@@ -16,19 +16,16 @@ void _mlir_ciface_corr_2d(MemRef<float, 2> *input, MemRef<float, 2> *kernel,
                           unsigned int centerY, int boundaryOption);
 }
 
-bool equalImages(const Mat &img1, const Mat &img2)
-{
+bool equalImages(const Mat &img1, const Mat &img2) {
   if (img1.rows != img2.rows || img1.cols != img2.cols) {
-    std::cout << "Produced outputs by DIP and OpenCV differ. Image dimensions are not equal\n";
+    std::cout << "Produced outputs by DIP and OpenCV differ. Image dimensions "
+                 "are not equal\n";
     return 0;
   }
 
-  for (unsigned int y = 0; y < img1.rows; ++y)
-  {
-    for (unsigned int x = 0; x < img1.cols; ++x)
-    {
-      if (abs(img1.at<float>(x, y) - img2.at<float>(x, y)) > 10e-3)
-      {
+  for (unsigned int y = 0; y < img1.rows; ++y) {
+    for (unsigned int x = 0; x < img1.cols; ++x) {
+      if (abs(img1.at<float>(x, y) - img2.at<float>(x, y)) > 10e-3) {
         std::cout << "Produced outputs by DIP and OpenCV differ.\n";
         return 0;
       }
@@ -37,9 +34,9 @@ bool equalImages(const Mat &img1, const Mat &img2)
   return 1;
 }
 
-void testKernelImpl(const Mat& inputImage, unsigned int kernelRows, unsigned int kernelCols, float* kernelArray, 
-                unsigned int x, unsigned int y)
-{
+void testKernelImpl(const Mat &inputImage, unsigned int kernelRows,
+                    unsigned int kernelCols, float *kernelArray, unsigned int x,
+                    unsigned int y) {
   // Define container sizes.
   intptr_t sizesInput[2] = {inputImage.rows, inputImage.cols};
   intptr_t sizesKernel[2] = {kernelRows, kernelCols};
@@ -60,31 +57,33 @@ void testKernelImpl(const Mat& inputImage, unsigned int kernelRows, unsigned int
   _mlir_ciface_corr_2d(&input, &kernel, &output, x, y, 0);
 
   filter2D(inputImage, opencvOutput, CV_32FC1, kernel1, cv::Point(x, y), 1.0,
-        cv::BORDER_REPLICATE);
+           cv::BORDER_REPLICATE);
 
   // Define a cv::Mat with the output of corr_2d.
   Mat dipOutput(inputImage.rows, inputImage.cols, CV_32FC1, output.getData());
 
-  if (!equalImages(dipOutput, opencvOutput))
-  {
-    std::cout << "Different images produced by OpenCV and DIP for kernel :\n" << kernel1 << "\n"
-        "when anchor point was : (" << x << ", " << y << ").\n";
+  if (!equalImages(dipOutput, opencvOutput)) {
+    std::cout << "Different images produced by OpenCV and DIP for kernel :\n"
+              << kernel1
+              << "\n"
+                 "when anchor point was : ("
+              << x << ", " << y << ").\n";
     return;
   }
 }
 
-void testKernel(const Mat& inputImage, unsigned int kernelRows, unsigned int kernelCols, float* kernelArray)
-{
+void testKernel(const Mat &inputImage, unsigned int kernelRows,
+                unsigned int kernelCols, float *kernelArray) {
   for (unsigned int y = 0; y < kernelRows; ++y)
     for (unsigned int x = 0; x < kernelCols; ++x)
       testKernelImpl(inputImage, kernelRows, kernelCols, kernelArray, x, y);
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
   // Read input image
   Mat inputImage = imread(argv[1], IMREAD_GRAYSCALE);
 
   for (auto kernel : kernelMap)
-    testKernel(inputImage, get<1>(kernel.second), get<2>(kernel.second), get<0>(kernel.second));
+    testKernel(inputImage, get<1>(kernel.second), get<2>(kernel.second),
+               get<0>(kernel.second));
 }


### PR DESCRIPTION
This PR intends to add support for testing `dip.corr_2d`'s output with OpenCV. 
All available kernels were used for correlating an image using DIP and OpenCV followed by comparison of their respective outputs.