### PR TITLE
Improve image generation and initialisation in IP benchmarks

### DIFF
--- a/benchmarks/ImageProcessing/BuddyConv2DBenchmark.cpp
+++ b/benchmarks/ImageProcessing/BuddyConv2DBenchmark.cpp
@@ -47,7 +47,7 @@ intptr_t sizesInputBuddyConv2D[2];
 intptr_t sizesKernelBuddyConv2D[2];
 intptr_t sizesOutputBuddyConv2D[2];
 
-void initializeBuddyConv2D(int argc, char **argv) {
+void initializeBuddyConv2D(char **argv) {
   inputImageBuddyConv2D = imread(argv[1], IMREAD_GRAYSCALE);
   kernelBuddyConv2DMat =
       Mat(get<1>(kernelMap[argv[2]]), get<2>(kernelMap[argv[2]]), CV_32FC1,
@@ -91,10 +91,10 @@ static void Buddy_Conv2D(benchmark::State &state) {
 BENCHMARK(Buddy_Conv2D)->Arg(1);
 
 // Generate result image.
-void generateResultBuddyConv2D() {
+void generateResultBuddyConv2D(char **argv) {
   // Define the MemRef descriptor for input, kernel, and output.
   MemRef<float, 2> input(inputImageBuddyConv2D, sizesInputBuddyConv2D);
-  MemRef<float, 2> kernel(kernelBuddyConv2DMat, sizesKernelBuddyConv2D);
+  MemRef<float, 2> kernel(get<0>(kernelMap[argv[2]]), sizesKernelBuddyConv2D);
   MemRef<float, 2> output(sizesOutputBuddyConv2D);
   // Run the 2D convolution.
   _mlir_ciface_buddy_conv_2d(&input, &kernel, &output);

--- a/benchmarks/ImageProcessing/BuddyCorr2DBenchmark.cpp
+++ b/benchmarks/ImageProcessing/BuddyCorr2DBenchmark.cpp
@@ -49,7 +49,7 @@ intptr_t sizesInputBuddyCorr2D[2];
 intptr_t sizesKernelBuddyCorr2D[2];
 intptr_t sizesOutputBuddyCorr2D[2];
 
-void initializeBuddyCorr2D(int argc, char **argv) {
+void initializeBuddyCorr2D(char **argv) {
   inputImageBuddyCorr2D = imread(argv[1], IMREAD_GRAYSCALE);
   kernelBuddyCorr2DMat =
       Mat(get<1>(kernelMap[argv[2]]), get<2>(kernelMap[argv[2]]), CV_32FC1,
@@ -92,10 +92,10 @@ static void Buddy_Corr2D(benchmark::State &state) {
 BENCHMARK(Buddy_Corr2D)->Arg(1);
 
 // Generate result image.
-void generateResultBuddyCorr2D() {
+void generateResultBuddyCorr2D(char **argv) {
   // Define the MemRef descriptor for input, kernel, and output.
   MemRef<float, 2> input(inputImageBuddyCorr2D, sizesInputBuddyCorr2D);
-  MemRef<float, 2> kernel(kernelBuddyCorr2DMat, sizesKernelBuddyCorr2D);
+  MemRef<float, 2> kernel(get<0>(kernelMap[argv[2]]), sizesKernelBuddyCorr2D);
   MemRef<float, 2> output(sizesOutputBuddyCorr2D);
   // Run the 2D correlation.
   _mlir_ciface_corr_2d(&input, &kernel, &output, 1 /* Center X */,

--- a/benchmarks/ImageProcessing/MLIRConv2DBenchmark.cpp
+++ b/benchmarks/ImageProcessing/MLIRConv2DBenchmark.cpp
@@ -47,7 +47,7 @@ intptr_t sizesInputMLIRConv2D[2];
 intptr_t sizesKernelMLIRConv2D[2];
 intptr_t sizesOutputMLIRConv2D[2];
 
-void initializeMLIRConv2D(int argc, char **argv) {
+void initializeMLIRConv2D(char **argv) {
   inputImageMLIRConv2D = imread(argv[1], IMREAD_GRAYSCALE);
   kernelMLIRConv2DMat =
       Mat(get<1>(kernelMap[argv[2]]), get<2>(kernelMap[argv[2]]), CV_32FC1,

--- a/benchmarks/ImageProcessing/Main.cpp
+++ b/benchmarks/ImageProcessing/Main.cpp
@@ -20,13 +20,13 @@
 
 #include <benchmark/benchmark.h>
 
-void initializeMLIRConv2D(int, char **);
-void initializeBuddyConv2D(int, char **);
-void initializeBuddyCorr2D(int, char **);
-void initializeOpenCVFilter2D(int, char **);
+void initializeMLIRConv2D(char **);
+void initializeBuddyConv2D(char **);
+void initializeBuddyCorr2D(char **);
+void initializeOpenCVFilter2D(char **);
 
-void generateResultBuddyConv2D();
-void generateResultBuddyCorr2D();
+void generateResultBuddyConv2D(char **);
+void generateResultBuddyCorr2D(char **);
 
 // Run benchmarks.
 int main(int argc, char **argv) {
@@ -41,16 +41,16 @@ int main(int argc, char **argv) {
         "include/ImageProcessing/Kernels.h\n");
   }
 
-  initializeMLIRConv2D(argc, argv);
-  initializeBuddyConv2D(argc, argv);
-  initializeBuddyCorr2D(argc, argv);
-  initializeOpenCVFilter2D(argc, argv);
+  initializeMLIRConv2D(argv);
+  initializeBuddyConv2D(argv);
+  initializeBuddyCorr2D(argv);
+  initializeOpenCVFilter2D(argv);
 
   ::benchmark::Initialize(&argc, argv);
   ::benchmark::RunSpecifiedBenchmarks();
   // Generate result image.
-  generateResultBuddyConv2D();
-  generateResultBuddyCorr2D();
+  generateResultBuddyConv2D(argv);
+  generateResultBuddyCorr2D(argv);
 
   return 0;
 }

--- a/benchmarks/ImageProcessing/OpenCVFilter2DBenchmark.cpp
+++ b/benchmarks/ImageProcessing/OpenCVFilter2DBenchmark.cpp
@@ -28,7 +28,7 @@ using namespace std;
 // Declare input image, kernel and output image.
 Mat inputImageFilter2D, kernelFilter2D, outputFilter2D;
 
-void initializeOpenCVFilter2D(int argc, char **argv) {
+void initializeOpenCVFilter2D(char **argv) {
   inputImageFilter2D = imread(argv[1], IMREAD_GRAYSCALE);
 
   kernelFilter2D = Mat(get<1>(kernelMap[argv[2]]), get<2>(kernelMap[argv[2]]),


### PR DESCRIPTION
This PR intends to fix `generateResultBuddyCorr2D` and `generateResultBuddyConv2D` so that the resulting images are in agreement with `OpenCV`. 
I have also removed an unnecessary argument from initialisation functions. 