### PR TITLE
Improve MemRef container for reading images

### DIFF
--- a/benchmarks/DeepLearning/Models/Inception-V3/InceptionBenchmark.cpp
+++ b/benchmarks/DeepLearning/Models/Inception-V3/InceptionBenchmark.cpp
@@ -50,7 +50,7 @@ cv::Mat image = imagePreprocessing();
 intptr_t sizesInput[4] = {1, image.rows, image.cols, 3};
 intptr_t sizesOutnput[2] = {1, 1001};
 
-MemRef<float, 4> input(image, sizesInput);
+MemRef<float, 4> input(image, sizesInput, IMAGE_MATRIX_OPERATION::NORMALIZE_AND_TRANSPOSE);
 MemRef<float, 2> output(sizesOutnput);
 
 // Define benchmark function.

--- a/benchmarks/DeepLearning/Models/MobileNet-V2/MobileNetBenchmark.cpp
+++ b/benchmarks/DeepLearning/Models/MobileNet-V2/MobileNetBenchmark.cpp
@@ -49,7 +49,7 @@ cv::Mat image = imagePreprocessing();
 intptr_t sizesInput[4] = {1, image.rows, image.cols, 3};
 intptr_t sizesOutnput[2] = {1, 1001};
 
-MemRef<float, 4> input(image, sizesInput);
+MemRef<float, 4> input(image, sizesInput, IMAGE_MATRIX_OPERATION::NORMALIZE_AND_TRANSPOSE);
 MemRef<float, 2> output(sizesOutnput);
 
 // Define benchmark function.

--- a/benchmarks/DeepLearning/Models/MobileNet-V3/MobileNetBenchmark.cpp
+++ b/benchmarks/DeepLearning/Models/MobileNet-V3/MobileNetBenchmark.cpp
@@ -50,7 +50,7 @@ cv::Mat image = imagePreprocessing();
 intptr_t sizesInput[4] = {1, image.rows, image.cols, 3};
 intptr_t sizesOutnput[2] = {1, 1001};
 
-MemRef<float, 4> input(image, sizesInput);
+MemRef<float, 4> input(image, sizesInput, IMAGE_MATRIX_OPERATION::NORMALIZE_AND_TRANSPOSE);
 MemRef<float, 2> output(sizesOutnput);
 
 // Define benchmark function.

--- a/benchmarks/DeepLearning/Models/ResNet-V2-50/ResNetBenchmark.cpp
+++ b/benchmarks/DeepLearning/Models/ResNet-V2-50/ResNetBenchmark.cpp
@@ -49,7 +49,7 @@ cv::Mat image = imagePreprocessing();
 intptr_t sizesInput[4] = {1, image.rows, image.cols, 3};
 intptr_t sizesOutput[2] = {1, 1001};
 
-MemRef<float, 4> input(image, sizesInput);
+MemRef<float, 4> input(image, sizesInput, IMAGE_MATRIX_OPERATION::NORMALIZE_AND_TRANSPOSE);
 MemRef<float, 2> output(sizesOutput);
 
 // Define benchmark function.

--- a/include/Utils/Container.h
+++ b/include/Utils/Container.h
@@ -28,6 +28,13 @@
 
 #include "Utils/PNGImage.h"
 
+enum class IMAGE_MATRIX_OPERATION {
+  DEFAULT,
+  NORMALIZE,
+  NORMALIZE_AND_TRANSPOSE,
+  TRANSPOSE
+};
+
 // MemRef descriptor.
 // - T represents the type of the elements.
 // - N represents the number of dimensions.
@@ -40,12 +47,15 @@ public:
   MemRef(intptr_t sizes[N], T init = T(0));
   MemRef(std::vector<size_t> sizes, T init = T(0));
   // Create a memref from an opencv image.
-  MemRef(cv::Mat image, intptr_t sizes[N]);
+  MemRef(cv::Mat image, intptr_t sizes[N],
+         IMAGE_MATRIX_OPERATION operation = IMAGE_MATRIX_OPERATION::DEFAULT);
   // Constructor from a png image.
-  MemRef(const PNGImage &img, intptr_t sizes[N]);
+  MemRef(const PNGImage &img, intptr_t sizes[N],
+         IMAGE_MATRIX_OPERATION operation = IMAGE_MATRIX_OPERATION::DEFAULT);
   // Constructor from a vector of png images.
   // Assume that all the images have the same shape.
-  MemRef(const std::vector<PNGImage> &imgs, intptr_t sizes[N]);
+  MemRef(const std::vector<PNGImage> &imgs, intptr_t sizes[N],
+         IMAGE_MATRIX_OPERATION operation = IMAGE_MATRIX_OPERATION::DEFAULT);
   // Copy constructor.
   MemRef(const MemRef<T, N> &other);
   // Copy assignment operator.

--- a/include/Utils/Container.h
+++ b/include/Utils/Container.h
@@ -28,6 +28,8 @@
 
 #include "Utils/PNGImage.h"
 
+// ToDo : Identify the proper usecase which requires "TRANSPOSE" operation.
+
 enum class IMAGE_MATRIX_OPERATION {
   DEFAULT,
   NORMALIZE,

--- a/tests/UnitTests/CMakeLists.txt
+++ b/tests/UnitTests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(
 target_link_libraries(
   test-container
   gtest_main
+  ${OpenCV_LIBS}
 )
 
 add_dependencies(test-container Container)

--- a/tests/UnitTests/TestContainer.cpp
+++ b/tests/UnitTests/TestContainer.cpp
@@ -20,6 +20,7 @@
 
 #include "Test.h"
 #include "Utils/Container.h"
+#include <opencv2/opencv.hpp>
 
 // Fixture for testing the MemRef class.
 class MemRefTest : public ::testing::Test {
@@ -193,6 +194,56 @@ TEST_F(MemRefTest, TransposeNCHWToNHWC) {
   size_t n_data = sizeof(true_data) / sizeof(float);
   ASSERT_EQ(transposed.getSize(), n_data);
   ASSERT_ARRAY_EQ(transposed.getData(), true_data, n_data);
+}
+
+TEST_F(MemRefTest, ImageNormalization) {
+  cv::Mat testImage = cv::imread(
+      "../../benchmarks/ImageProcessing/Images/YuTu.png", cv::IMREAD_GRAYSCALE);
+  intptr_t testImageDimensions[2] = {testImage.rows, testImage.cols};
+  MemRef<float, 2> testImageMemref(testImage, testImageDimensions,
+                                   IMAGE_MATRIX_OPERATION::NORMALIZE);
+  unsigned int testImageSize = testImage.rows * testImage.cols, k = 0;
+  float *true_data = new float[testImageSize];
+
+  for (unsigned int i = 0; i < testImage.rows; ++i)
+    for (unsigned int j = 0; j < testImage.cols; ++j)
+      true_data[k] = testImage.at<uchar>(i, j) / 255.0f, ++k;
+
+  ASSERT_ARRAY_EQ(testImageMemref.getData(), true_data, testImageSize);
+}
+
+TEST_F(MemRefTest, ImageTranspose) {
+  cv::Mat testImage = cv::imread(
+      "../../benchmarks/ImageProcessing/Images/YuTu.png", cv::IMREAD_GRAYSCALE);
+  intptr_t testImageDimensions[2] = {testImage.rows, testImage.cols};
+  MemRef<float, 2> testImageMemref(testImage, testImageDimensions,
+                                   IMAGE_MATRIX_OPERATION::TRANSPOSE);
+  unsigned int testImageSize = testImage.rows * testImage.cols;
+
+  cv::transpose(testImage, testImage);
+  intptr_t testImageTransposeDimensions[2] = {testImage.rows, testImage.cols};
+  MemRef<float, 2> trueImageMemref(testImage, testImageTransposeDimensions);
+
+  ASSERT_ARRAY_EQ(testImageMemref.getData(), trueImageMemref.getData(),
+                  testImageSize);
+}
+
+TEST_F(MemRefTest, ImageNormalizeAndTranspose) {
+  cv::Mat testImage = cv::imread(
+      "../../benchmarks/ImageProcessing/Images/YuTu.png", cv::IMREAD_GRAYSCALE);
+  intptr_t testImageDimensions[2] = {testImage.rows, testImage.cols};
+  MemRef<float, 2> testImageMemref(
+      testImage, testImageDimensions,
+      IMAGE_MATRIX_OPERATION::NORMALIZE_AND_TRANSPOSE);
+  unsigned int testImageSize = testImage.rows * testImage.cols, k = 0;
+  cv::transpose(testImage, testImage);
+  float *true_data = new float[testImageSize];
+
+  for (unsigned int i = 0; i < testImage.rows; ++i)
+    for (unsigned int j = 0; j < testImage.cols; ++j)
+      true_data[k] = testImage.at<uchar>(i, j) / 255.0f, ++k;
+
+  ASSERT_ARRAY_EQ(testImageMemref.getData(), true_data, testImageSize);
 }
 
 // Copy constructor.


### PR DESCRIPTION
This PR intends to provide more control on `normalization` and `transpose` operations while reading images in `MemRef` container.  Users can now specify whether they want transposed/normalized copies of their images in `MemRef` container while constructing the `MemRef` object in their program. 
