### PR TITLE
Update audio processing benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ mkdir build && cd build
 $ cmake -G Ninja .. \
     -DAUDIO_PROCESSING_BENCHMARKS=ON \
     -DCMAKE_CXX_COMPILER=clang++ \
-    -DKFR_DIR=/PATH/TO/KFR/SOURCE/CODE \
+    -DKFR_DIR=/PATH/TO/KFR/SOURCE/CODE 
 $ ninja audio-processing-benchmark
 ```
 

--- a/benchmarks/AudioProcessing/CMakeLists.txt
+++ b/benchmarks/AudioProcessing/CMakeLists.txt
@@ -7,7 +7,9 @@ add_subdirectory(${KFR_DIR} ./kfr)
 include_directories(${KFR_DIR}/include)
 
 add_executable(audio-processing-benchmark
+  KFRFft.cpp
   KFRFir.cpp 
+  KFRBiquad.cpp
   Main.cpp
 )
 

--- a/benchmarks/AudioProcessing/KFRBiquad.cpp
+++ b/benchmarks/AudioProcessing/KFRBiquad.cpp
@@ -1,0 +1,55 @@
+//===- KFRBiquad.cpp ---------------------------------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the benchmark for KFR Biquad function.
+//
+//===----------------------------------------------------------------------===//
+
+#include <benchmark/benchmark.h>
+#include <kfr/base.hpp>
+#include <kfr/dft.hpp>
+#include <kfr/dsp.hpp>
+#include <kfr/io.hpp>
+#include <kfr/math.hpp>
+#include <kfr/dsp/biquad.hpp>
+#include <kfr/all.hpp>
+
+using namespace kfr;
+
+univector<float, 2000000> aud_biquad;
+biquad_params<double> bq = {biquad_lowpass(0.3, -1.0)};
+// Initialize univector.
+void initializeKFRBiquad() {
+  audio_reader_wav<float> reader(open_file_for_reading(
+      "../../benchmarks/AudioProcessing/Audios/NASA_Mars.wav"));
+  reader.read(aud_biquad.data(), aud_biquad.size());
+}
+
+// Benchmarking function.
+static void KFR_Biquad(benchmark::State &state) {
+  for (auto _ : state) {
+    for (int i = 0; i < state.range(0); ++i) {
+        aud_biquad = biquad(bq, aud_biquad);
+    }
+  }
+}
+
+// Register benchmarking function.
+BENCHMARK(KFR_Biquad)->Arg(1); 
+
+void generateResultKFRBiquad() {
+  println("Biquad operation finished!");
+}

--- a/benchmarks/AudioProcessing/KFRFft.cpp
+++ b/benchmarks/AudioProcessing/KFRFft.cpp
@@ -1,0 +1,56 @@
+//===- KFRFft.cpp ---------------------------------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the benchmark for KFR Fft function.
+//
+//===----------------------------------------------------------------------===//
+
+#include <benchmark/benchmark.h>
+#include <kfr/base.hpp>
+#include <kfr/dft.hpp>
+#include <kfr/dsp.hpp>
+#include <kfr/io.hpp>
+#include <kfr/simd/complex.hpp>
+#include <kfr/dft/reference_dft.hpp>
+using namespace kfr;
+
+dft_plan_real<float> plan(2000000);   // dft_plan_real for real transform
+univector<float, 2000000> aud_fft;
+univector<complex<float>, 2000000> freq;
+univector<u8> temp(plan.temp_size);
+
+// Initialize univector.
+void initializeKFRFft() {
+  audio_reader_wav<float> reader(open_file_for_reading(
+      "../../benchmarks/AudioProcessing/Audios/NASA_Mars.wav"));
+  reader.read(aud_fft.data(), aud_fft.size());
+}
+
+// Benchmarking function.
+static void KFR_FFT(benchmark::State &state) {
+  for (auto _ : state) {
+    for (int i = 0; i < state.range(0); ++i) {
+      plan.execute(freq, aud_fft, temp);
+    }
+  }
+}
+
+// Register benchmarking function.
+BENCHMARK(KFR_FFT)->Arg(1);
+
+void generateResultKFRFft() {
+  println("FFT operation finished!");
+}

--- a/benchmarks/AudioProcessing/Main.cpp
+++ b/benchmarks/AudioProcessing/Main.cpp
@@ -21,13 +21,21 @@
 #include <benchmark/benchmark.h>
 
 void initializeKFRFir();
+void initializeKFRBiquad();
+void initializeKFRFft();
 
 void generateResultKFRFir();
+void generateResultKFRBiquad();
+void generateResultKFRFft();
 
 int main(int argc, char **argv) {
   initializeKFRFir();
+  initializeKFRBiquad();
+  initializeKFRFft();
   ::benchmark::Initialize(&argc, argv);
   ::benchmark::RunSpecifiedBenchmarks();
   generateResultKFRFir();
+  generateResultKFRBiquad();
+  generateResultKFRFft();
   return 0;
 }


### PR DESCRIPTION
1. Add Fft operation benchmark & Biquad operation benchmark.
2. delete '\\' at the end of the cmake options