### PR TITLE
Use conditional compilation to generate Container file based on speci…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,15 @@ endif()
 if(DEFINED IMAGE_PROCESSING_BENCHMARKS OR DEEP_LEARNING_BENCHMARKS)
   find_package(OpenCV REQUIRED CONFIG)
   include_directories(${OpenCV_INCLUDE_DIRS})
+  add_compile_options(-DIMAGE_CONTAINER)
+endif()
+
+#-------------------------------------------------------------------------------
+# Find kfr
+#-------------------------------------------------------------------------------
+
+if(DEFINED AUDIO_PROCESSING_BENCHMARKS)
+  add_compile_options(-DAUDIO_CONTAINER)
 endif()
 
 #-------------------------------------------------------------------------------

--- a/include/Utils/Container.h
+++ b/include/Utils/Container.h
@@ -22,11 +22,21 @@
 #define UTILS_CONTAINER
 
 #include <memory>
-#include <opencv2/opencv.hpp>
+
 #include <stdint.h>
 #include <vector>
 
+#ifdef AUDIO_CONTAINER
+#include <kfr/base.hpp>
+#include <kfr/dft.hpp>
+#include <kfr/dsp.hpp>
+#include <kfr/io.hpp>
+#endif
+
+#ifdef IMAGE_CONTAINER
+#include <opencv2/opencv.hpp>
 #include "Utils/PNGImage.h"
+#endif
 
 // ToDo : Identify the proper usecase which requires "TRANSPOSE" operation.
 
@@ -36,7 +46,7 @@ enum class IMAGE_MATRIX_OPERATION {
   NORMALIZE_AND_TRANSPOSE,
   TRANSPOSE
 };
-
+#endif
 // MemRef descriptor.
 // - T represents the type of the elements.
 // - N represents the number of dimensions.
@@ -48,6 +58,7 @@ public:
   // Constructor from shape.
   MemRef(intptr_t sizes[N], T init = T(0));
   MemRef(std::vector<size_t> sizes, T init = T(0));
+  #ifdef IMAGE_CONTAINER
   // Create a memref from an opencv image.
   MemRef(cv::Mat image, intptr_t sizes[N],
          IMAGE_MATRIX_OPERATION operation = IMAGE_MATRIX_OPERATION::DEFAULT);
@@ -58,6 +69,14 @@ public:
   // Assume that all the images have the same shape.
   MemRef(const std::vector<PNGImage> &imgs, intptr_t sizes[N],
          IMAGE_MATRIX_OPERATION operation = IMAGE_MATRIX_OPERATION::DEFAULT);
+  #endif
+  #ifdef AUDIO_CONTAINER
+  // Constructor from KFR univector. 
+  MemRef(const kfr::univector<T>, intptr_t sizes[N]);
+  // Constructor from KFR univector2d.
+  // Data layout is determined by sizes[N]. 
+  MemRef(const kfr::univector2d<T>, intptr_t sizes[N]);
+  #endif
   // Copy constructor.
   MemRef(const MemRef<T, N> &other);
   // Copy assignment operator.

--- a/lib/Utils/Container.cpp
+++ b/lib/Utils/Container.cpp
@@ -78,7 +78,7 @@ MemRef<T, N>::MemRef(std::vector<size_t> sizes, T init) {
   allocated = data;
   std::fill(data, data + size, init);
 }
-
+#ifdef IMAGE_CONTAINER
 template <typename T, size_t N>
 MemRef<T, N>::MemRef(cv::Mat image, intptr_t sizes[N],
                      IMAGE_MATRIX_OPERATION operation) {
@@ -224,7 +224,47 @@ MemRef<T, N>::MemRef(const std::vector<PNGImage> &imgs, intptr_t sizes[N],
   aligned = data;
   allocated = data;
 }
+#endif
+#ifdef AUDIO_CONTAINER
+template <typename T, std::size_t N>
+MemRef<T, N>::MemRef(const kfr::univector<T> aud, intptr_t sizes[N]) {
+  static_assert(N == 1, "When data container is univerctor<T> type, the constructor only support mono audio.");
+  this->offset = 0;
+  for (size_t i = 0; i < N; i++) {
+    this->sizes[i] = sizes[i];
+  }
+  setStrides();
+  size = product(sizes);
+  T *ptr = new T[size];
+  this->aligned = ptr;
+  this->allocated = ptr;
+  for(int i = 0; i < aud.size(); i++) {
+    *ptr = aud[i];
+    ptr++;
+  }
+}
 
+template <typename T, std::size_t N>
+MemRef<T, N>::MemRef(const kfr::univector2d<T> aud, intptr_t sizes[N]) {
+  static_assert(N == 2, "When data container is univector2d<T> type, the constructor only support stereo audio.");
+  printf("Testing!!!\n");
+  this->offset = 0;
+  for (size_t i = 0; i < N; i++) {
+    this->sizes[i] = sizes[i];
+  }
+  setStrides();
+  size = product(sizes);
+  T *ptr = new T[size];
+  this->aligned = ptr;
+  this->allocated = ptr;
+  for(int i = 0; i < this->sizes[0]; i++) {
+    for(int j = 0; j < this->sizes[1]; j++){
+      *ptr = aud[i][j];
+      ptr++;
+    }
+  }
+}
+#endif
 template <typename T, std::size_t N>
 MemRef<T, N>::MemRef(const MemRef<T, N> &other)
     : offset(other.offset), size(other.size) {


### PR DESCRIPTION
1. This commit added MemRef constructor for audio processing.

- kfr::univector<T, N> contains data for mono audio, kfr:: univector2d<T, N> contains data for stereo audio.

2. This commit will generate Container file(both .h and .cpp) according to cmake options. 

- For example, if "-DIMAGE_PROCESSING_BENCHMARKS=ON" were stated after the cmake command, then the Container file will contain constructors for image processing. Same, when using "-DAUDIO_PROCESSING_BENCHMARKS=ON", the Container file contains audio constructors. State both options will obtain the Container file with all constructors.

**Note：**
This scheme(using conditional compilation) may be **replaced** by inheritance scheme using base class and derived class in future.