### PR TITLE
Biquad IIR implementation for DAP dialect

### DIFF
--- a/benchmarks/AudioProcessing/BuddyBiquad.mlir
+++ b/benchmarks/AudioProcessing/BuddyBiquad.mlir
@@ -1,0 +1,52 @@
+//===- BuddyBiquad.mlir ---------------------------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides the MLIR Biquad IIR function.
+//
+//===----------------------------------------------------------------------===//
+
+func.func @buddy_biquad(%in : memref<?xf32>, %filter : memref<?xf32>, %out : memref<?xf32>) {
+  %c0 = arith.constant 0 : index
+  %N = memref.dim %in, %c0 : memref<?xf32>
+  %b0 = affine.load %filter[0] : memref<?xf32>
+  %b1 = affine.load %filter[1] : memref<?xf32>
+  %b2 = affine.load %filter[2] : memref<?xf32>
+  %a1 = affine.load %filter[3] : memref<?xf32>
+  %a2 = affine.load %filter[4] : memref<?xf32>
+  %init_z1 = arith.constant 0.0 : f32
+  %init_z2 = arith.constant 0.0 : f32
+
+  %res:2 = affine.for %i = 0 to %N iter_args(%z1 = %init_z1, %z2 = %init_z2) {
+    %input = affine.load %in[%i] : memref<?xf32>
+    %t0 = arith.mulf %b0, %input
+    %output = arith.addf %t0, %z1
+
+    %t1 = arith.mulf %b1, %input
+    %t2 = arith.mulf %a1, %output
+    %t3 = arith.subf %t1, %t2
+    %z1_next = arith.addf %z2, %t3
+
+    %t4 = arith.mulf %b2, %input
+    %t5 = arith.mulf %a2, %output
+    %z2_next = arith.subf %t4, %t5
+
+    affine.store %output, %out[%i] : memref<?xf32>
+
+    affine.yield %z1_next, %z2_next : f32, f32
+
+  }
+  return
+}

--- a/benchmarks/AudioProcessing/BuddyBiquad.mlir
+++ b/benchmarks/AudioProcessing/BuddyBiquad.mlir
@@ -18,7 +18,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-func.func @buddy_biquad(%in : memref<?xf32>, %filter : memref<?xf32>, %out : memref<?xf32>) {
+func.func @buddy_biquad(%in : memref<?xf32>, %filter : memref<?xf32>, %out : memref<?xf32>){
   %c0 = arith.constant 0 : index
   %N = memref.dim %in, %c0 : memref<?xf32>
   %b0 = affine.load %filter[0] : memref<?xf32>

--- a/benchmarks/AudioProcessing/BuddyBiquad.mlir
+++ b/benchmarks/AudioProcessing/BuddyBiquad.mlir
@@ -29,19 +29,19 @@ func.func @buddy_biquad(%in : memref<?xf32>, %filter : memref<?xf32>, %out : mem
   %init_z1 = arith.constant 0.0 : f32
   %init_z2 = arith.constant 0.0 : f32
 
-  %res:2 = affine.for %i = 0 to %N iter_args(%z1 = %init_z1, %z2 = %init_z2) {
+  %res:2 = affine.for %i = 0 to %N iter_args(%z1 = %init_z1, %z2 = %init_z2) -> (f32, f32) {
     %input = affine.load %in[%i] : memref<?xf32>
-    %t0 = arith.mulf %b0, %input
-    %output = arith.addf %t0, %z1
+    %t0 = arith.mulf %b0, %input : f32
+    %output = arith.addf %t0, %z1 : f32
 
-    %t1 = arith.mulf %b1, %input
-    %t2 = arith.mulf %a1, %output
-    %t3 = arith.subf %t1, %t2
-    %z1_next = arith.addf %z2, %t3
+    %t1 = arith.mulf %b1, %input : f32
+    %t2 = arith.mulf %a1, %output : f32
+    %t3 = arith.subf %t1, %t2 : f32
+    %z1_next = arith.addf %z2, %t3 : f32
 
-    %t4 = arith.mulf %b2, %input
-    %t5 = arith.mulf %a2, %output
-    %z2_next = arith.subf %t4, %t5
+    %t4 = arith.mulf %b2, %input : f32
+    %t5 = arith.mulf %a2, %output : f32
+    %z2_next = arith.subf %t4, %t5 : f32
 
     affine.store %output, %out[%i] : memref<?xf32>
 

--- a/benchmarks/AudioProcessing/BuddyBiquadBenchmark.cpp
+++ b/benchmarks/AudioProcessing/BuddyBiquadBenchmark.cpp
@@ -1,4 +1,5 @@
-//===- BuddyBiquadBenchmark.cpp ---------------------------------------------------------===//
+//===- BuddyBiquadBenchmark.cpp
+//---------------------------------------------------------===//
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,39 +32,45 @@ extern "C" {
 void _mlir_ciface_buddy_biquad(MemRef<float, 1> *inputBuddyConv1D,
                                MemRef<float, 1> *kernelBuddyConv1D,
                                MemRef<float, 1> *outputBuddyConv1D);
-
 }
+
 namespace {
-univector<float,5>kernel = {0.226053, 0.452106, 0.226053, -0.404376, 0.308588}; 
-univector<float, 2000000> aud;
-univector<float> result;
-int sizeofKernel = kernel.size();
-int sizeofAud{aud.size()};
+univector<float, 5> kernel;
+biquad_params<float> bq = {biquad_lowpass(0.3, -1.0)};
+
+univector<float, 2000000> aud_buddy_biquad;
+univector<float, 2000000> result_buddy_biquad;
+intptr_t sizeofKernel{kernel.size()};
+intptr_t sizeofAud{aud_buddy_biquad.size()};
 
 // MemRef copys all data, so data here are actually not accessed.
-MemRef<float,1> kernelRef(reinterpret_cast<intptr_t *>(&sizeofKernel));
-MemRef<float,1> audRef(reinterpret_cast<intptr_t *>(&sizeofAud));
-MemRef<float,1> resRef(reinterpret_cast<intptr_t *>(&sizeofAud));
-}
+MemRef<float, 1> kernelRef(&sizeofKernel);
+MemRef<float, 1> audRef(&sizeofAud);
+MemRef<float, 1> resRef(&sizeofAud);
+} // namespace
 
 // Initialize univector.
 void initializeBuddyBiquad() {
-  audio_reader_wav<float> reader(open_file_for_reading(
+  audio_reader_wav<float> reader_buddy_biquad(open_file_for_reading(
       "../../benchmarks/AudioProcessing/Audios/NASA_Mars.wav"));
-  reader.read(aud.data(), aud.size());
-  kernelRef=std::move(MemRef<float,1>(kernel.data(),
-                              reinterpret_cast<intptr_t *>(&sizeofKernel)));
-  audRef=std::move(MemRef<float,1>(aud.data(),
-                          reinterpret_cast<intptr_t *>(&sizeofAud)));
-  resRef=std::move(MemRef<float,1>(reinterpret_cast<intptr_t *>(&sizeofAud)));
+  reader_buddy_biquad.read(aud_buddy_biquad.data(), aud_buddy_biquad.size());
+
+  kernel[0] = bq.b0;
+  kernel[1] = bq.b1;
+  kernel[2] = bq.b2;
+  kernel[3] = bq.a1;
+  kernel[4] = bq.a2;
+
+  kernelRef = std::move(MemRef<float, 1>(kernel.data(), &sizeofKernel));
+  audRef = std::move(MemRef<float, 1>(aud_buddy_biquad.data(), &sizeofAud));
+  resRef = std::move(MemRef<float, 1>(&sizeofAud));
 }
 
 // Benchmarking function.
 static void BUDDY_BIQUAD(benchmark::State &state) {
   for (auto _ : state) {
     for (int i = 0; i < state.range(0); ++i) {
-      // result = kfr::fir(aud, taps127);
-      _mlir_ciface_buddy_biquad(&audRef,&kernelRef,&resRef);
+      _mlir_ciface_buddy_biquad(&audRef, &kernelRef, &resRef);
     }
   }
 }
@@ -71,15 +78,17 @@ static void BUDDY_BIQUAD(benchmark::State &state) {
 // Register benchmarking function.
 BENCHMARK(BUDDY_BIQUAD)->Arg(1);
 
-// Generate result wav file.
+// Generate result_buddy_biquad wav file.
 void generateResultBuddyBiquad() {
-  MemRef<float,1> generateResult(reinterpret_cast<intptr_t *>(&sizeofAud));
-  _mlir_ciface_buddy_biquad(&audRef,&kernelRef,&generateResult);
+  println("-------------------------------------------------------");
+  println("[ Buddy Biquad Result Information ]");
+  MemRef<float, 1> generateResult(&sizeofAud);
+  _mlir_ciface_buddy_biquad(&audRef, &kernelRef, &generateResult);
 
-  audio_writer_wav<float> writer(open_file_for_writing("./ResultBuddyBiqaud.wav"),
-                                 audio_format{1 /* channel */,
-                                              audio_sample_type::i24,
-                                              100000 /* sample rate */});
+  audio_writer_wav<float> writer(
+      open_file_for_writing("./ResultBuddyBiqaud.wav"),
+      audio_format{1 /* channel */, audio_sample_type::i24,
+                   100000 /* sample rate */});
   writer.write(generateResult.getData(), generateResult.getSize());
   println("Sample Rate  = ", writer.format().samplerate);
   println("Channels     = ", writer.format().channels);

--- a/benchmarks/AudioProcessing/BuddyBiquadBenchmark.cpp
+++ b/benchmarks/AudioProcessing/BuddyBiquadBenchmark.cpp
@@ -1,0 +1,90 @@
+//===- BuddyBiquadBenchmark.cpp ---------------------------------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the benchmark for Buddy Biquad IIR function.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Utils/Container.h"
+#include <benchmark/benchmark.h>
+#include <kfr/base.hpp>
+#include <kfr/dft.hpp>
+#include <kfr/dsp.hpp>
+#include <kfr/io.hpp>
+
+using namespace kfr;
+
+extern "C" {
+void _mlir_ciface_buddy_biquad(MemRef<float, 1> *inputBuddyConv1D,
+                               MemRef<float, 1> *kernelBuddyConv1D,
+                               MemRef<float, 1> *outputBuddyConv1D);
+
+}
+namespace {
+univector<float,5>kernel = {0.226053, 0.452106, 0.226053, -0.404376, 0.308588}; 
+univector<float, 2000000> aud;
+univector<float> result;
+int sizeofKernel = kernel.size();
+int sizeofAud{aud.size()};
+
+// MemRef copys all data, so data here are actually not accessed.
+MemRef<float,1> kernelRef(reinterpret_cast<intptr_t *>(&sizeofKernel));
+MemRef<float,1> audRef(reinterpret_cast<intptr_t *>(&sizeofAud));
+MemRef<float,1> resRef(reinterpret_cast<intptr_t *>(&sizeofAud));
+}
+
+// Initialize univector.
+void initializeBuddyBiquad() {
+  audio_reader_wav<float> reader(open_file_for_reading(
+      "../../benchmarks/AudioProcessing/Audios/NASA_Mars.wav"));
+  reader.read(aud.data(), aud.size());
+  kernelRef=std::move(MemRef<float,1>(kernel.data(),
+                              reinterpret_cast<intptr_t *>(&sizeofKernel)));
+  audRef=std::move(MemRef<float,1>(aud.data(),
+                          reinterpret_cast<intptr_t *>(&sizeofAud)));
+  resRef=std::move(MemRef<float,1>(reinterpret_cast<intptr_t *>(&sizeofAud)));
+}
+
+// Benchmarking function.
+static void BUDDY_BIQUAD(benchmark::State &state) {
+  for (auto _ : state) {
+    for (int i = 0; i < state.range(0); ++i) {
+      // result = kfr::fir(aud, taps127);
+      _mlir_ciface_buddy_biquad(&audRef,&kernelRef,&resRef);
+    }
+  }
+}
+
+// Register benchmarking function.
+BENCHMARK(BUDDY_BIQUAD)->Arg(1);
+
+// Generate result wav file.
+void generateResultBuddyBiquad() {
+  MemRef<float,1> generateResult(reinterpret_cast<intptr_t *>(&sizeofAud));
+  _mlir_ciface_buddy_biquad(&audRef,&kernelRef,&generateResult);
+
+  audio_writer_wav<float> writer(open_file_for_writing("./ResultBuddyBiqaud.wav"),
+                                 audio_format{1 /* channel */,
+                                              audio_sample_type::i24,
+                                              100000 /* sample rate */});
+  writer.write(generateResult.getData(), generateResult.getSize());
+  println("Sample Rate  = ", writer.format().samplerate);
+  println("Channels     = ", writer.format().channels);
+  println("Length       = ", writer.format().length);
+  println("Duration (s) = ",
+          writer.format().length / writer.format().samplerate);
+  println("Bit depth    = ", audio_sample_bit_depth(writer.format().type));
+}

--- a/benchmarks/AudioProcessing/CMakeLists.txt
+++ b/benchmarks/AudioProcessing/CMakeLists.txt
@@ -6,12 +6,30 @@ add_subdirectory(${KFR_DIR} ./kfr)
 
 include_directories(${KFR_DIR}/include)
 
+
+
+add_custom_command(OUTPUT buddy-biquad.o
+        COMMAND ${BUDDY_OPT_BUILD_DIR}/bin/buddy-opt
+        ${BUDDY_SOURCE_DIR}/benchmarks/AudioProcessing/BuddyBiquad.mlir
+        -convert-linalg-to-affine-loops
+        -lower-affine -convert-scf-to-cf -convert-vector-to-llvm
+        -convert-memref-to-llvm -convert-func-to-llvm='emit-c-wrappers=1'
+        -reconcile-unrealized-casts |
+        ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
+        ${LLVM_MLIR_BINARY_DIR}/llc -mtriple=${BUDDY_OPT_TRIPLE}
+        -mattr=${BUDDY_OPT_ATTR} --filetype=obj
+        -o ${BUDDY_BINARY_DIR}/../benchmarks/AudioProcessing/buddy-biquad.o
+        )
+add_library(BuddyBiquad STATIC buddy-biquad.o)
+set_target_properties(BuddyBiquad PROPERTIES LINKER_LANGUAGE CXX)
+
 add_executable(audio-processing-benchmark
   KFRFft.cpp
   KFRFir.cpp 
   KFRBiquad.cpp
   KFRIir.cpp
   Main.cpp
+  BuddyBiquadBenchmark.cpp
 )
 
 target_link_directories(audio-processing-benchmark PRIVATE ${KFR_DIR}/build/)
@@ -19,5 +37,6 @@ target_link_libraries(audio-processing-benchmark
   PRIVATE
   kfr_io
   kfr_dft
+  BuddyBiquad
   GoogleBenchmark
 )

--- a/benchmarks/AudioProcessing/CMakeLists.txt
+++ b/benchmarks/AudioProcessing/CMakeLists.txt
@@ -13,9 +13,9 @@ add_custom_command(OUTPUT buddy-biquad.o
         ${BUDDY_SOURCE_DIR}/benchmarks/AudioProcessing/BuddyBiquad.mlir
         -lower-dap -convert-linalg-to-affine-loops
         -lower-affine -convert-scf-to-cf -convert-vector-to-llvm 
+        --llvm-request-c-wrappers
         -convert-arith-to-llvm
         -convert-memref-to-llvm -convert-func-to-llvm
-        --llvm-request-c-wrappers
         -reconcile-unrealized-casts |
         ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
         ${LLVM_MLIR_BINARY_DIR}/llc -mtriple=${BUDDY_OPT_TRIPLE} 
@@ -30,8 +30,8 @@ add_executable(audio-processing-benchmark
   KFRFir.cpp 
   KFRBiquad.cpp
   KFRIir.cpp
-  Main.cpp
   BuddyBiquadBenchmark.cpp
+  Main.cpp
 )
 
 target_link_directories(audio-processing-benchmark PRIVATE ${KFR_DIR}/build/)

--- a/benchmarks/AudioProcessing/CMakeLists.txt
+++ b/benchmarks/AudioProcessing/CMakeLists.txt
@@ -11,14 +11,16 @@ include_directories(${KFR_DIR}/include)
 add_custom_command(OUTPUT buddy-biquad.o
         COMMAND ${BUDDY_OPT_BUILD_DIR}/bin/buddy-opt
         ${BUDDY_SOURCE_DIR}/benchmarks/AudioProcessing/BuddyBiquad.mlir
-        -convert-linalg-to-affine-loops
-        -lower-affine -convert-scf-to-cf -convert-vector-to-llvm
-        -convert-memref-to-llvm -convert-func-to-llvm='emit-c-wrappers=1'
+        -lower-dap -convert-linalg-to-affine-loops
+        -lower-affine -convert-scf-to-cf -convert-vector-to-llvm 
+        -convert-arith-to-llvm
+        -convert-memref-to-llvm -convert-func-to-llvm
+        --llvm-request-c-wrappers
         -reconcile-unrealized-casts |
         ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-        ${LLVM_MLIR_BINARY_DIR}/llc -mtriple=${BUDDY_OPT_TRIPLE}
-        -mattr=${BUDDY_OPT_ATTR} --filetype=obj
-        -o ${BUDDY_BINARY_DIR}/../benchmarks/AudioProcessing/buddy-biquad.o
+        ${LLVM_MLIR_BINARY_DIR}/llc -mtriple=${BUDDY_OPT_TRIPLE} 
+            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
+            -o ${BUDDY_BINARY_DIR}/../benchmarks/AudioProcessing/buddy-biquad.o
         )
 add_library(BuddyBiquad STATIC buddy-biquad.o)
 set_target_properties(BuddyBiquad PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/AudioProcessing/KFRBiquad.cpp
+++ b/benchmarks/AudioProcessing/KFRBiquad.cpp
@@ -1,4 +1,5 @@
-//===- KFRBiquad.cpp ---------------------------------------------------------===//
+//===- KFRBiquad.cpp
+//---------------------------------------------------------===//
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,39 +20,46 @@
 //===----------------------------------------------------------------------===//
 
 #include <benchmark/benchmark.h>
+#include <kfr/all.hpp>
 #include <kfr/base.hpp>
 #include <kfr/dft.hpp>
 #include <kfr/dsp.hpp>
+#include <kfr/dsp/biquad.hpp>
 #include <kfr/io.hpp>
 #include <kfr/math.hpp>
-#include <kfr/dsp/biquad.hpp>
-#include <kfr/all.hpp>
 
 using namespace kfr;
 
 univector<float, 2000000> aud_biquad;
-biquad_params<double> bq = {biquad_lowpass(0.3, -1.0)};
+biquad_params<float> bq = {biquad_lowpass(0.3, -1.0)};
+univector<float, 2000000> result_biquad;
 // Initialize univector.
 void initializeKFRBiquad() {
-  audio_reader_wav<float> reader(open_file_for_reading(
+  audio_reader_wav<float> reader_biquad(open_file_for_reading(
       "../../benchmarks/AudioProcessing/Audios/NASA_Mars.wav"));
-  reader.read(aud_biquad.data(), aud_biquad.size());
+  reader_biquad.read(aud_biquad.data(), aud_biquad.size());
 }
 
 // Benchmarking function.
 static void KFR_Biquad(benchmark::State &state) {
   for (auto _ : state) {
     for (int i = 0; i < state.range(0); ++i) {
-        aud_biquad = biquad(bq, aud_biquad);
+      result_biquad = biquad(bq, aud_biquad);
     }
   }
 }
 
 // Register benchmarking function.
-BENCHMARK(KFR_Biquad)->Arg(1); 
+BENCHMARK(KFR_Biquad)->Arg(1);
 
 void generateResultKFRBiquad() {
   println("-------------------------------------------------------");
   println("[ KFR Biquad Result Information ]");
+  result_biquad = biquad(bq, aud_biquad);
+  audio_writer_wav<float> writer(open_file_for_writing("./ResultKFRBiqaud.wav"),
+                                 audio_format{1 /* channel */,
+                                              audio_sample_type::i24,
+                                              100000 /* sample rate */});
+  writer.write(result_biquad.data(), result_biquad.size());
   println("Biquad operation finished!");
 }

--- a/benchmarks/AudioProcessing/Main.cpp
+++ b/benchmarks/AudioProcessing/Main.cpp
@@ -24,22 +24,27 @@ void initializeKFRFir();
 void initializeKFRBiquad();
 void initializeKFRFft();
 void initializeKFRIir();
+void initializeBuddyBiquad();
 
 void generateResultKFRFir();
 void generateResultKFRBiquad();
 void generateResultKFRFft();
 void generateResultKFRIir();
+void generateResultBuddyBiquad();
 
 int main(int argc, char **argv) {
   initializeKFRFir();
   initializeKFRBiquad();
   initializeKFRFft();
   initializeKFRIir();
+  initializeBuddyBiquad();
   ::benchmark::Initialize(&argc, argv);
   ::benchmark::RunSpecifiedBenchmarks();
   generateResultKFRFir();
   generateResultKFRBiquad();
   generateResultKFRFft();
   generateResultKFRIir();
+  generateResultBuddyBiquad();
+
   return 0;
 }


### PR DESCRIPTION
Add `buddy biquad IIR` benchmark, in comparison to kfr's biquad implementation.

![image](https://user-images.githubusercontent.com/64468582/180845481-aa5067f0-1549-43dc-a9db-3248c1964ee6.png)
