### PR TITLE
Fix classification bug for ResNet18DefaultBenchmark

### DIFF
--- a/benchmarks/DeepLearning/Models/Inception-V3/InceptionBenchmark.cpp
+++ b/benchmarks/DeepLearning/Models/Inception-V3/InceptionBenchmark.cpp
@@ -50,7 +50,7 @@ cv::Mat image = imagePreprocessing();
 intptr_t sizesInput[4] = {1, image.rows, image.cols, 3};
 intptr_t sizesOutnput[2] = {1, 1001};
 
-Img<float, 4> input(image, true);
+Img<float, 4> input(image, sizesInput, true);
 MemRef<float, 2> output(sizesOutnput);
 
 // Define benchmark function.

--- a/benchmarks/DeepLearning/Models/MobileNet-V2/MobileNetBenchmark.cpp
+++ b/benchmarks/DeepLearning/Models/MobileNet-V2/MobileNetBenchmark.cpp
@@ -50,7 +50,7 @@ cv::Mat image = imagePreprocessing();
 intptr_t sizesInput[4] = {1, image.rows, image.cols, 3};
 intptr_t sizesOutnput[2] = {1, 1001};
 
-Img<float, 4> input(image, true);
+Img<float, 4> input(image, sizesInput, true);
 MemRef<float, 2> output(sizesOutnput);
 
 // Define benchmark function.

--- a/benchmarks/DeepLearning/Models/MobileNet-V3/MobileNetBenchmark.cpp
+++ b/benchmarks/DeepLearning/Models/MobileNet-V3/MobileNetBenchmark.cpp
@@ -50,8 +50,7 @@ cv::Mat image = imagePreprocessing();
 intptr_t sizesInput[4] = {1, image.rows, image.cols, 3};
 intptr_t sizesOutnput[2] = {1, 1001};
 
-// MemRef<float, 4> input(image, sizesInput, IMAGE_MATRIX_OPERATION::NORMALIZE);
-Img<float, 4> input(image, true);
+Img<float, 4> input(image, sizesInput, true);
 MemRef<float, 2> output(sizesOutnput);
 
 // Define benchmark function.

--- a/benchmarks/DeepLearning/Models/ResNet-18/ResNet18DefaultBenchmark.cpp
+++ b/benchmarks/DeepLearning/Models/ResNet-18/ResNet18DefaultBenchmark.cpp
@@ -35,7 +35,6 @@ void _mlir_ciface_forward(MemRef<float, 2> *output, Img<float, 4> *input);
 }
 
 const cv::Mat imagePreprocessing() {
-  // std::cout << "preprocessing!!!" << std::endl;
   cv::Mat inputImage =
       cv::imread("../../benchmarks/DeepLearning/Models/ResNet-18/Images/"
                  "YellowLabradorLooking_new.jpg");
@@ -50,10 +49,10 @@ const cv::Mat imagePreprocessing() {
 
 cv::Mat image = imagePreprocessing();
 
-intptr_t sizesInput[4] = {1, image.rows, image.cols, 3};
+intptr_t sizesInput[4] = {1, 3, image.rows, image.cols};
 intptr_t sizesOutput[2] = {1, 1000};
 
-Img<float, 4> input(image, true);
+Img<float, 4> input(image, sizesInput, true);
 MemRef<float, 2> output(sizesOutput);
 
 // Define benchmark function.

--- a/benchmarks/DeepLearning/Models/ResNet-V2-50/ResNetBenchmark.cpp
+++ b/benchmarks/DeepLearning/Models/ResNet-V2-50/ResNetBenchmark.cpp
@@ -50,7 +50,7 @@ cv::Mat image = imagePreprocessing();
 intptr_t sizesInput[4] = {1, image.rows, image.cols, 3};
 intptr_t sizesOutput[2] = {1, 1001};
 
-Img<float, 4> input(image, true);
+Img<float, 4> input(image, sizesInput, true);
 MemRef<float, 2> output(sizesOutput);
 
 // Define benchmark function.


### PR DESCRIPTION
**This change is based on [this PR from buddy-mlir](https://github.com/buddy-compiler/buddy-mlir/pull/111).**

Change the input data layout from NHWC to NCHW to fix the classification bug of ResNet18DefaultBenchmark. 

Pytorch is using NCHW to store image input. Since ResNet18DefaultBenchmark is based on 'ResNet-18.mlir' which is converted from a torch model, the input's layout should also be NCHW instead of the default setting NHWC in ImgContainer. After modification the following correct output of ResNet18DefaultBenchmark can be reached:
```
Classification Index: 208
Classification: Labrador retriever
Probability: 0.348121
```

For other deep learning benchmarks, data layouts are also explictly given to avoid confusion.