### PR TITLE
Compile and run deep learning benchmark on RISC-V

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,13 @@ include_directories(${BUDDY_MLIR_LIB_DIR})
 
 # MLIR binary directory.
 set(LLVM_MLIR_BINARY_DIR ${BUDDY_MLIR_BUILD_DIR}/../llvm/build/bin)
-set(LLVM_MLIR_LIBRARY_DIR ${BUDDY_MLIR_BUILD_DIR}/../llvm/build/lib)
+
+if(CMAKE_TOOLCHAIN_FILE STREQUAL ${BUDDY_SOURCE_DIR}/cmake/riscv-toolchain.cmake)
+  # Use cross-compiled RISC-V MLIR library.
+  set(LLVM_MLIR_LIBRARY_DIR ${BUDDY_MLIR_BUILD_DIR}/../llvm/build-cross-mlir/lib)
+else()
+  set(LLVM_MLIR_LIBRARY_DIR ${BUDDY_MLIR_BUILD_DIR}/../llvm/build/lib)
+endif()
 
 # Helper functions.
 include(${BUDDY_SOURCE_DIR}/cmake/buddy-benchmark.cmake)
@@ -62,6 +68,7 @@ ExternalProject_Add(project_googlebenchmark
   TIMEOUT 10
   BUILD_BYPRODUCTS <INSTALL_DIR>/lib/${CMAKE_STATIC_LIBRARY_PREFIX}benchmark${CMAKE_STATIC_LIBRARY_SUFFIX}
   CMAKE_ARGS
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
     -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/vendor/benchmark
     -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
     -DBENCHMARK_ENABLE_TESTING=OFF

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ $ cmake -G Ninja .. \
 $ ninja
 ```
 
+### Models and Operations
 The deep learning benchmark includes the following e2e models and operations:
 
 - MobileNet
@@ -100,6 +101,33 @@ Run the DepthwiseConv2DNhwcHwc operation benchmark:
 
 ```
 $ cd <path to build>/bin && ./depthwise-conv-2d-nhwc-hwc-benchmark
+```
+### Cross-compilation on RISC-V
+Deep learning benchmark is also supported on RISC-V. To set up environments for RISC-V cross compilation and run the benchmarks:
+1. Build riscv-gnu-toolchain, QEMU and cross-compiled MLIR according to [this link](https://gist.github.com/zhanghb97/ad44407e169de298911b8a4235e68497).
+2. Cross-compile OpenCV on RISC-V:
+```
+$ cd opencv
+$ mkdir build && cd build
+$ cmake -DCMAKE_TOOLCHAIN_FILE=../platforms/linux/riscv64-gcc.toolchain.cmake ../
+$ make -j$(nproc)
+```
+3. Change the path of `RISCV_TOOLCHAIN_ROOT` in buddy-benchmark/cmake/riscv-toolchain.cmake to where your riscv-gnu-toolchain root directory is built.
+4. Cross-compile deep learning benchmark with CMAKE_TOOLCHAIN_FILE being set:
+```
+$ cd buddy-benchmark
+$ mkdir build && cd build
+$ cmake .. -DCMAKE_TOOLCHAIN_FILE=/PATH/TO/BUDDY-BENCHMARK/cmake/riscv-toolchain.cmake \
+    -G Ninja \
+    -DDEEP_LEARNING_BENCHMARKS=ON \
+    -DOpenCV_DIR=/PATH/TO/OPENCV/BUILD/ \
+    -DBUDDY_MLIR_BUILD_DIR=/PATH/TO/BUDDY-MLIR/BUILD/
+$ ninja
+```
+5. Use QEMU to run RISC-V executable files:
+```
+$ cd <path to build>/bin
+$ <path to qemu-riscv64> -L <path to riscv-gnu-toolchain sysroot> -cpu rv64,x-v=true,vlen=128 ./mobilenet-benchmark
 ```
 
 ## Audio Processing Benchmark

--- a/benchmarks/DeepLearning/Models/ResNet-18/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Models/ResNet-18/CMakeLists.txt
@@ -1,35 +1,70 @@
 set(RESNET18_TOSA_PIPELINE "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-tensor),func.func(tosa-to-linalg),func.func(tosa-to-arith))")
 
 # Compile MLIR file to object file.
-add_custom_command(OUTPUT resnet-18-default.o
-COMMAND 
-  ${LLVM_MLIR_BINARY_DIR}/mlir-opt ${CMAKE_CURRENT_SOURCE_DIR}/ResNet-18.mlir
-    --pass-pipeline="${RESNET18_TOSA_PIPELINE}" | 
-  ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-    --test-linalg-transform-patterns="test-generalize-pad-tensor"
-    --linalg-bufferize
-    --convert-linalg-to-loops
-    --func-bufferize
-    --arith-bufferize
-    --tensor-bufferize 
-    --finalizing-bufferize
-    --convert-vector-to-scf
-    --convert-scf-to-cf
-    --expand-strided-metadata
-    --lower-affine
-    --convert-vector-to-llvm
-    --memref-expand
-    --arith-expand
-    --convert-arith-to-llvm
-    --convert-memref-to-llvm
-    --convert-math-to-llvm
-    --llvm-request-c-wrappers
-    --convert-func-to-llvm
-    --reconcile-unrealized-casts |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-  ${LLVM_MLIR_BINARY_DIR}/llc -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} 
-    --filetype=obj -o ${CMAKE_CURRENT_BINARY_DIR}/resnet-18-default.o
-)
+if(CMAKE_TOOLCHAIN_FILE STREQUAL ${BUDDY_SOURCE_DIR}/cmake/riscv-toolchain.cmake)
+  # Generate RISC-V object file.
+  add_custom_command(OUTPUT resnet-18-default.o
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/mlir-opt ${CMAKE_CURRENT_SOURCE_DIR}/ResNet-18.mlir
+      --pass-pipeline="${RESNET18_TOSA_PIPELINE}" |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-opt
+      --test-linalg-transform-patterns="test-generalize-pad-tensor"
+      --linalg-bufferize
+      --convert-linalg-to-loops
+      --func-bufferize
+      --arith-bufferize
+      --tensor-bufferize
+      --finalizing-bufferize
+      --convert-vector-to-scf
+      --convert-scf-to-cf
+      --expand-strided-metadata
+      --lower-affine
+      --convert-vector-to-llvm
+      --memref-expand
+      --arith-expand
+      --convert-arith-to-llvm
+      --convert-memref-to-llvm
+      --convert-math-to-llvm
+      --llvm-request-c-wrappers
+      --convert-func-to-llvm
+      --reconcile-unrealized-casts |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
+    ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple riscv64 -target-abi lp64d
+    -mattr=+m,+d,+v --filetype=obj -riscv-v-vector-bits-min=128
+    -o ${CMAKE_CURRENT_BINARY_DIR}/resnet-18-default.o
+  )
+else()
+  # Generate x86 object file.
+  add_custom_command(OUTPUT resnet-18-default.o
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/mlir-opt ${CMAKE_CURRENT_SOURCE_DIR}/ResNet-18.mlir
+      --pass-pipeline="${RESNET18_TOSA_PIPELINE}" |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-opt
+      --test-linalg-transform-patterns="test-generalize-pad-tensor"
+      --linalg-bufferize
+      --convert-linalg-to-loops
+      --func-bufferize
+      --arith-bufferize
+      --tensor-bufferize
+      --finalizing-bufferize
+      --convert-vector-to-scf
+      --convert-scf-to-cf
+      --expand-strided-metadata
+      --lower-affine
+      --convert-vector-to-llvm
+      --memref-expand
+      --arith-expand
+      --convert-arith-to-llvm
+      --convert-memref-to-llvm
+      --convert-math-to-llvm
+      --llvm-request-c-wrappers
+      --convert-func-to-llvm
+      --reconcile-unrealized-casts |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
+    ${LLVM_MLIR_BINARY_DIR}/llc -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR}
+      --filetype=obj -o ${CMAKE_CURRENT_BINARY_DIR}/resnet-18-default.o
+  )
+endif()
 
 add_library(ResNet18Default STATIC resnet-18-default.o)
 set_target_properties(ResNet18Default PROPERTIES LINKER_LANGUAGE CXX)

--- a/cmake/riscv-toolchain.cmake
+++ b/cmake/riscv-toolchain.cmake
@@ -1,0 +1,25 @@
+##===- riscv-toolchain.cmake ----------------------------------------------===//
+##
+## Cross-compile benchmarks for RISC-V.
+##
+##===----------------------------------------------------------------------===//
+
+if(RISCV_TOOLCHAIN_INCLUDED)
+  return()
+endif(RISCV_TOOLCHAIN_INCLUDED)
+set(RISCV_TOOLCHAIN_INCLUDED true)
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR riscv64)
+
+# Set RISC-V toolchain path.
+set(RISCV_TOOLCHAIN_ROOT "/root/riscv-gnu-toolchain/install")
+set(CMAKE_FIND_ROOT_PATH ${RISCV_TOOLCHAIN_ROOT})
+list(APPEND CMAKE_PREFIX_PATH ${RISCV_TOOLCHAIN_ROOT})
+set(CMAKE_C_COMPILER "${RISCV_TOOLCHAIN_ROOT}/bin/riscv64-unknown-linux-gnu-gcc")
+set(CMAKE_CXX_COMPILER "${RISCV_TOOLCHAIN_ROOT}/bin/riscv64-unknown-linux-gnu-g++")
+
+# Comfigure RISC-V compiler flags.
+set(RISCV_COMPILER_FLAGS "-march=rv64i2p0ma2p0f2p0d2p0c2p0 -mabi=lp64d")
+set(CMAKE_C_FLAGS "${RISCV_COMPILER_FLAGS} ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "${RISCV_COMPILER_FLAGS} ${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
1. Add support for deep learning benchmark(including all models and ops) on RISC-V. Cross-compilation can be triggered by CMAKE_TOOLCHAIN_FILE variable which is passed to cmake. 
2. Add riscv-toolchain.cmake file for configuration.
3. Update README.md to show how to compile and run deep learning benchmark on RISC-V.


