### PR TITLE
[Vectorization] Fix the linpackc benchmark framework

### DIFF
--- a/benchmarks/Vectorization/linpackc/MLIRLinpackCDaxpyBenchmark.cpp
+++ b/benchmarks/Vectorization/linpackc/MLIRLinpackCDaxpyBenchmark.cpp
@@ -24,39 +24,36 @@
 
 // Declare the linpackcdaxpy C interface.
 extern "C" {
-void _mlir_ciface_mlir_linpackcdaxpyrollf32(size_t n, float da,
-                                            MemRef<float, 1> *dx, size_t incx,
-                                            MemRef<float, 1> *dy, size_t incy);
-void _mlir_ciface_mlir_linpackcdaxpyrollf64(size_t n, double da,
-                                            MemRef<double, 1> *dx, size_t incx,
-                                            MemRef<double, 1> *dy, size_t incy);
-void _mlir_ciface_mlir_linpackcdaxpyunrollf32(size_t n, float da,
-                                              MemRef<float, 1> *dx, size_t incx,
-                                              MemRef<float, 1> *dy,
-                                              size_t incy);
-void _mlir_ciface_mlir_linpackcdaxpyunrollf64(size_t n, double da,
-                                              MemRef<double, 1> *dx,
-                                              size_t incx,
-                                              MemRef<double, 1> *dy,
-                                              size_t incy);
+void _mlir_ciface_mlir_linpackcdaxpyrollf32(int n, float da,
+                                            MemRef<float, 1> *dx, int incx,
+                                            MemRef<float, 1> *dy, int incy);
+void _mlir_ciface_mlir_linpackcdaxpyrollf64(int n, double da,
+                                            MemRef<double, 1> *dx, int incx,
+                                            MemRef<double, 1> *dy, int incy);
+void _mlir_ciface_mlir_linpackcdaxpyunrollf32(int n, float da,
+                                              MemRef<float, 1> *dx, int incx,
+                                              MemRef<float, 1> *dy, int incy);
+void _mlir_ciface_mlir_linpackcdaxpyunrollf64(int n, double da,
+                                              MemRef<double, 1> *dx, int incx,
+                                              MemRef<double, 1> *dy, int incy);
 }
 
 // Define input and output sizes.
-intptr_t sizesArrayMLIRLinpackCDaxpy[1] = {10};
-size_t n = 10;
-size_t input_incx = 1;
-size_t input_incy = 1;
+constexpr int n = 10;
+constexpr int input_incx = -1;
+constexpr int input_incy = 2;
+constexpr int size_x = input_incx < 0 ? -input_incx : input_incx;
+constexpr int size_y = input_incy < 0 ? -input_incy : input_incy;
+constexpr int size = size_x < size_y ? size_y : size_x;
+
+intptr_t sizesArrayMLIRLinpackCDaxpy[1] = {intptr_t(n * size)};
 // Define the MemRef container for inputs and output.
-float input_dx_f32[10] = {1.2, 2.3, 3.4, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1, 10.2};
 float input_da_f32 = 10.3;
-MemRef<float, 1> inputMLIRDaxpy_dxf32(input_dx_f32,
-                                      sizesArrayMLIRLinpackCDaxpy);
+MemRef<float, 1> inputMLIRDaxpy_dxf32(sizesArrayMLIRLinpackCDaxpy, 2.3);
 MemRef<float, 1> outputMLIRDaxpy_f32(sizesArrayMLIRLinpackCDaxpy, 0.0);
 
-double input_dx_f64[10] = {1.2, 2.3, 3.4, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1, 10.2};
 double input_da_f64 = 10.3;
-MemRef<double, 1> inputMLIRDaxpy_dxf64(input_dx_f64,
-                                       sizesArrayMLIRLinpackCDaxpy);
+MemRef<double, 1> inputMLIRDaxpy_dxf64(sizesArrayMLIRLinpackCDaxpy, 2.3);
 MemRef<double, 1> outputMLIRDaxpy_f64(sizesArrayMLIRLinpackCDaxpy, 0.0);
 
 // Define the benchmark function.
@@ -109,57 +106,53 @@ BENCHMARK(MLIR_DaxpyUnrollF64)->Arg(1);
 // Generate result image.
 void generateResultMLIRLinpackCDaxpy() {
   // Define the MemRef descriptor for inputs and output.
-  float input_dx_f32[10] = {1.2, 2.3, 3.4, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1, 10.2};
-  float input_da_f32 = 10.3;
-  MemRef<float, 1> inputMLIRDaxpy_dxf32(input_dx_f32,
-                                        sizesArrayMLIRLinpackCDaxpy);
+  MemRef<float, 1> inputMLIRDaxpy_dxf32(sizesArrayMLIRLinpackCDaxpy, 2.3);
   MemRef<float, 1> outputMLIRDaxpy_f32_roll(sizesArrayMLIRLinpackCDaxpy, 0.0);
   MemRef<float, 1> outputMLIRDaxpy_f32_unroll(sizesArrayMLIRLinpackCDaxpy, 0.0);
-
-  double input_dx_f64[10] = {1.2, 2.3, 3.4, 4.5, 5.6, 6.7, 7.8, 8.9, 9.1, 10.2};
-  double input_da_f64 = 10.3;
-  MemRef<double, 1> inputMLIRDaxpy_dxf64(input_dx_f64,
-                                         sizesArrayMLIRLinpackCDaxpy);
+  MemRef<double, 1> inputMLIRDaxpy_dxf64(sizesArrayMLIRLinpackCDaxpy, 2.3);
   MemRef<double, 1> outputMLIRDaxpy_f64_roll(sizesArrayMLIRLinpackCDaxpy, 0.0);
-  MemRef<double, 1> outputMLIRDaxpy_f64_unroll(sizesArrayMLIRLinpackCDaxpy,
-                                               0.0);
+  MemRef<double, 1> outputMLIRDaxpy_f64_unroll(sizesArrayMLIRLinpackCDaxpy,0.0);
   // Run the linpackcdaxpy.
   _mlir_ciface_mlir_linpackcdaxpyrollf32(n, input_da_f32, &inputMLIRDaxpy_dxf32,
                                          input_incx, &outputMLIRDaxpy_f32_roll,
                                          input_incy);
+
   _mlir_ciface_mlir_linpackcdaxpyunrollf32(
       n, input_da_f32, &inputMLIRDaxpy_dxf32, input_incx,
       &outputMLIRDaxpy_f32_unroll, input_incy);
+
   _mlir_ciface_mlir_linpackcdaxpyrollf64(n, input_da_f64, &inputMLIRDaxpy_dxf64,
                                          input_incx, &outputMLIRDaxpy_f64_roll,
                                          input_incy);
+
   _mlir_ciface_mlir_linpackcdaxpyunrollf64(
       n, input_da_f64, &inputMLIRDaxpy_dxf64, input_incx,
       &outputMLIRDaxpy_f64_unroll, input_incy);
   // Print the output.
   std::cout << "--------------------------------------------------------"
             << std::endl;
-  std::cout << "MLIR_LinpackC: MLIR Daxpy Operation" << std::endl;
+  std::cout << "MLIR_LinpackC: MLIR Daxpy Operation for 'incx = -1, incy = 2'"
+            << std::endl;
   std::cout << "f32roll: [ ";
-  for (size_t i = 0; i < outputMLIRDaxpy_f32_roll.getSize(); i++) {
+  for (size_t i = 0; i < n; i++) {
     std::cout << outputMLIRDaxpy_f32_roll.getData()[i] << " ";
   }
   std::cout << "]" << std::endl;
 
   std::cout << "f32unroll: [ ";
-  for (size_t i = 0; i < outputMLIRDaxpy_f32_unroll.getSize(); i++) {
+  for (size_t i = 0; i < n; i++) {
     std::cout << outputMLIRDaxpy_f32_unroll.getData()[i] << " ";
   }
   std::cout << "]" << std::endl;
 
   std::cout << "f64roll: [ ";
-  for (size_t i = 0; i < outputMLIRDaxpy_f64_roll.getSize(); i++) {
+  for (size_t i = 0; i < n; i++) {
     std::cout << outputMLIRDaxpy_f64_roll.getData()[i] << " ";
   }
   std::cout << "]" << std::endl;
 
   std::cout << "f64unroll: [ ";
-  for (size_t i = 0; i < outputMLIRDaxpy_f64_unroll.getSize(); i++) {
+  for (size_t i = 0; i < n; i++) {
     std::cout << outputMLIRDaxpy_f64_unroll.getData()[i] << " ";
   }
   std::cout << "]" << std::endl;

--- a/benchmarks/Vectorization/linpackc/MLIRLinpackCDaxpyRollF32.mlir
+++ b/benchmarks/Vectorization/linpackc/MLIRLinpackCDaxpyRollF32.mlir
@@ -19,18 +19,21 @@
 //===----------------------------------------------------------------------===//
 
 
-func.func @mlir_linpackcdaxpyrollf32(%n : index, %da : f32, %dx: memref<?xf32>, %incx : index, 
-                                   %dy: memref<?xf32>, %incy : index) {
+func.func @mlir_linpackcdaxpyrollf32(%n : i32, %da : f32, %dx: memref<?xf32>, %incx : i32,
+                                   %dy: memref<?xf32>, %incy : i32) {
   %c0 = arith.constant 0 : index
+  %i0 = arith.constant 0 : i32
   %c1 = arith.constant 1 : index
+  %i1 = arith.constant 1 : i32
   %c4 = arith.constant 4 : index
   %da_i = arith.fptosi %da : f32 to i32
   %da_index = arith.index_cast %da_i : i32 to index
+  %n_index = arith.index_cast %n : i32 to index
 
-  %cond1 = arith.cmpi "sle", %n, %c0 : index
+  %cond1 = arith.cmpi "sle", %n, %i0 : i32
   %cond2 = arith.cmpi "eq", %da_index, %c0 : index
-  %cond3 = arith.cmpi "ne", %incx, %c1 : index
-  %cond4 = arith.cmpi "ne", %incy, %c1 : index
+  %cond3 = arith.cmpi "ne", %incx, %i1 : i32
+  %cond4 = arith.cmpi "ne", %incy, %i1 : i32
   %cond5 = arith.ori %cond3, %cond4 : i1
 
   cf.cond_br %cond1, ^terminator, ^continue0
@@ -41,37 +44,45 @@ func.func @mlir_linpackcdaxpyrollf32(%n : index, %da : f32, %dx: memref<?xf32>, 
     cf.cond_br %cond5, ^continue2, ^continue3
 
   ^continue2:
-    %ix = arith.constant 0 : index
-    %iy = arith.constant 0 : index
-    %cond6 = arith.cmpi "slt", %incx, %c0 : index
-    %cond7 = arith.cmpi "slt", %incy, %c0 : index
-    %ix_0 = scf.if %cond6 -> (index) {
-      %tmp = arith.subi %c1, %n : index
-      %ix_1 = arith.muli %tmp, %incx : index
-      scf.yield %ix_1 : index
+    %ix = arith.constant 0 : i32
+    %iy = arith.constant 0 : i32
+    %cond6 = arith.cmpi "slt", %incx, %i0 : i32
+    %cond7 = arith.cmpi "slt", %incy, %i0 : i32
+    %ix_0 = scf.if %cond6 -> (i32) {
+      %tmp = arith.subi %i1, %n : i32
+      %ix_1 = arith.muli %tmp, %incx : i32
+      scf.yield %ix_1 : i32
     } else {
-      scf.yield %ix : index
+      scf.yield %ix : i32
     }
-    %iy_0 = scf.if %cond7 -> (index) {
-      %tmp = arith.subi %c1, %n : index
-      %iy_1 = arith.muli %tmp, %incy : index
-      scf.yield %iy_1 : index
+    %iy_0 = scf.if %cond7 -> (i32) {
+      %tmp = arith.subi %i1, %n : i32
+      %iy_1 = arith.muli %tmp, %incy : i32
+      scf.yield %iy_1 : i32
     } else{
-      scf.yield %iy : index
+      scf.yield %iy : i32
     }
-    scf.for %i_0 = %c0 to %n step %c1 {
-      %dx_val_0 = memref.load %dx[%ix_0] : memref<?xf32>
-      %dy_val_0 = memref.load %dy[%iy_0] : memref<?xf32>
+
+    %incx_index = arith.index_cast %incx : i32 to index
+    %incy_index = arith.index_cast %incy : i32 to index
+    %ix_0_index = arith.index_cast %ix_0 : i32 to index
+    %iy_0_index = arith.index_cast %iy_0 : i32 to index
+
+    %ix_3, %iy_3 = scf.for %i_0 = %c0 to %n_index step %c1
+    iter_args(%ix_4 = %ix_0_index, %iy_4 = %iy_0_index) -> (index, index){
+      %dx_val_0 = memref.load %dx[%ix_4] : memref<?xf32>
+      %dy_val_0 = memref.load %dy[%iy_4] : memref<?xf32>
       %result_0 = arith.mulf %da, %dx_val_0 : f32
       %new_dy_val_0 = arith.addf %dy_val_0, %result_0 : f32
-      memref.store %new_dy_val_0, %dy[%iy_0] : memref<?xf32>
-      %ix_2 = arith.addi %ix, %incx : index
-      %iy_2 = arith.addi %iy, %incy : index
+      memref.store %new_dy_val_0, %dy[%iy_4] : memref<?xf32>
+      %ix_2 = arith.addi %ix_4, %incx_index : index
+      %iy_2 = arith.addi %iy_4, %incy_index : index
+      scf.yield %ix_2, %iy_2 : index, index
     }
     return
 
   ^continue3:
-    scf.for %i_1 = %c0 to %n step %c1 {
+    scf.for %i_1 = %c0 to %n_index step %c1 {
       %dx_val_1 = memref.load %dx[%i_1] : memref<?xf32>
       %dy_val_1 = memref.load %dy[%i_1] : memref<?xf32>
       %result_1 = arith.mulf %da, %dx_val_1 : f32

--- a/benchmarks/Vectorization/linpackc/MLIRLinpackCDaxpyRollF64.mlir
+++ b/benchmarks/Vectorization/linpackc/MLIRLinpackCDaxpyRollF64.mlir
@@ -19,20 +19,23 @@
 //===----------------------------------------------------------------------===//
 
 
-func.func @mlir_linpackcdaxpyrollf64(%n : index, %da : f64, %dx: memref<?xf64>, %incx : index, 
-                                   %dy: memref<?xf64>, %incy : index) {
+func.func @mlir_linpackcdaxpyrollf64(%n : i32, %da : f64, %dx: memref<?xf64>, %incx : i32,
+                                   %dy: memref<?xf64>, %incy : i32) {
   %c0 = arith.constant 0 : index
+  %i0 = arith.constant 0 : i32
   %c1 = arith.constant 1 : index
+  %i1 = arith.constant 1 : i32
   %c4 = arith.constant 4 : index
-  %da_i = arith.fptosi %da : f64 to i64
-  %da_index = arith.index_cast %da_i : i64 to index
+  %da_i = arith.fptosi %da : f64 to i32
+  %da_index = arith.index_cast %da_i : i32 to index
+  %n_index = arith.index_cast %n : i32 to index
 
-  %cond1 = arith.cmpi "sle", %n, %c0 : index
+  %cond1 = arith.cmpi "sle", %n, %i0 : i32
   %cond2 = arith.cmpi "eq", %da_index, %c0 : index
-  %cond3 = arith.cmpi "ne", %incx, %c1 : index
-  %cond4 = arith.cmpi "ne", %incy, %c1 : index
+  %cond3 = arith.cmpi "ne", %incx, %i1 : i32
+  %cond4 = arith.cmpi "ne", %incy, %i1 : i32
   %cond5 = arith.ori %cond3, %cond4 : i1
-  
+
   cf.cond_br %cond1, ^terminator, ^continue0
   ^continue0:
     cf.cond_br %cond2, ^terminator, ^continue1
@@ -41,37 +44,45 @@ func.func @mlir_linpackcdaxpyrollf64(%n : index, %da : f64, %dx: memref<?xf64>, 
     cf.cond_br %cond5, ^continue2, ^continue3
 
   ^continue2:
-    %ix = arith.constant 0 : index
-    %iy = arith.constant 0 : index
-    %cond6 = arith.cmpi "slt", %incx, %c0 : index
-    %cond7 = arith.cmpi "slt", %incy, %c0 : index
-    %ix_0 = scf.if %cond6 -> (index) {
-      %tmp = arith.subi %c1, %n : index
-      %ix_1 = arith.muli %tmp, %incx : index
-      scf.yield %ix_1 : index
+    %ix = arith.constant 0 : i32
+    %iy = arith.constant 0 : i32
+    %cond6 = arith.cmpi "slt", %incx, %i0 : i32
+    %cond7 = arith.cmpi "slt", %incy, %i0 : i32
+    %ix_0 = scf.if %cond6 -> (i32) {
+      %tmp = arith.subi %i1, %n : i32
+      %ix_1 = arith.muli %tmp, %incx : i32
+      scf.yield %ix_1 : i32
     } else {
-      scf.yield %ix : index
+      scf.yield %ix : i32
     }
-    %iy_0 = scf.if %cond7 -> (index) {
-      %tmp = arith.subi %c1, %n : index
-      %iy_1 = arith.muli %tmp, %incy : index
-      scf.yield %iy_1 : index
+    %iy_0 = scf.if %cond7 -> (i32) {
+      %tmp = arith.subi %i1, %n : i32
+      %iy_1 = arith.muli %tmp, %incy : i32
+      scf.yield %iy_1 : i32
     } else{
-      scf.yield %iy : index
+      scf.yield %iy : i32
     }
-    scf.for %i_0 = %c0 to %n step %c1 {
-      %dx_val_0 = memref.load %dx[%ix_0] : memref<?xf64>
-      %dy_val_0 = memref.load %dy[%iy_0] : memref<?xf64>
+
+    %incx_index = arith.index_cast %incx : i32 to index
+    %incy_index = arith.index_cast %incy : i32 to index
+    %ix_0_index = arith.index_cast %ix_0 : i32 to index
+    %iy_0_index = arith.index_cast %iy_0 : i32 to index
+
+    %ix_3, %iy_3 = scf.for %i_0 = %c0 to %n_index step %c1
+    iter_args(%ix_4 = %ix_0_index, %iy_4 = %iy_0_index) -> (index, index){
+      %dx_val_0 = memref.load %dx[%ix_4] : memref<?xf64>
+      %dy_val_0 = memref.load %dy[%iy_4] : memref<?xf64>
       %result_0 = arith.mulf %da, %dx_val_0 : f64
       %new_dy_val_0 = arith.addf %dy_val_0, %result_0 : f64
-      memref.store %new_dy_val_0, %dy[%iy_0] : memref<?xf64>
-      %ix_2 = arith.addi %ix, %incx : index
-      %iy_2 = arith.addi %iy, %incy : index
+      memref.store %new_dy_val_0, %dy[%iy_4] : memref<?xf64>
+      %ix_2 = arith.addi %ix_4, %incx_index : index
+      %iy_2 = arith.addi %iy_4, %incy_index : index
+      scf.yield %ix_2, %iy_2 : index, index
     }
     return
 
   ^continue3:
-    scf.for %i_1 = %c0 to %n step %c1 {
+    scf.for %i_1 = %c0 to %n_index step %c1 {
       %dx_val_1 = memref.load %dx[%i_1] : memref<?xf64>
       %dy_val_1 = memref.load %dy[%i_1] : memref<?xf64>
       %result_1 = arith.mulf %da, %dx_val_1 : f64

--- a/benchmarks/Vectorization/linpackc/MLIRLinpackCDaxpyUnrollF32.mlir
+++ b/benchmarks/Vectorization/linpackc/MLIRLinpackCDaxpyUnrollF32.mlir
@@ -19,21 +19,24 @@
 //===----------------------------------------------------------------------===//
 
 
-func.func @mlir_linpackcdaxpyunrollf32(%n : index, %da : f32, %dx: memref<?xf32>, %incx : index, 
-                                   %dy: memref<?xf32>, %incy : index) {
+func.func @mlir_linpackcdaxpyunrollf32(%n : i32, %da : f32, %dx: memref<?xf32>, %incx : i32,
+                                   %dy: memref<?xf32>, %incy : i32) {
   %c0 = arith.constant 0 : index
+  %i0 = arith.constant 0 : i32
   %c1 = arith.constant 1 : index
+  %i1 = arith.constant 1 : i32
   %c2 = arith.constant 2 : index
   %c3 = arith.constant 3 : index
   %c4 = arith.constant 4 : index
+  %n_index = arith.index_cast %n : i32 to index
   %da_i = arith.fptosi %da : f32 to i32
   %da_index = arith.index_cast %da_i : i32 to index
-  %m = arith.remui %n, %c4 : index
+  %m = arith.remui %n_index, %c4 : index
 
-  %cond1 = arith.cmpi "sle", %n, %c0 : index
+  %cond1 = arith.cmpi "sle", %n, %i0 : i32
   %cond2 = arith.cmpi "eq", %da_index, %c0 : index
-  %cond3 = arith.cmpi "ne", %incx, %c1 : index
-  %cond4 = arith.cmpi "ne", %incy, %c1 : index
+  %cond3 = arith.cmpi "ne", %incx, %i1 : i32
+  %cond4 = arith.cmpi "ne", %incy, %i1 : i32
   %cond5 = arith.ori %cond3, %cond4 : i1
   
   cf.cond_br %cond1, ^terminator, ^continue0
@@ -44,32 +47,40 @@ func.func @mlir_linpackcdaxpyunrollf32(%n : index, %da : f32, %dx: memref<?xf32>
     cf.cond_br %cond5, ^continue2, ^continue3
 
   ^continue2:
-    %ix = arith.constant 0 : index
-    %iy = arith.constant 0 : index
-    %cond6 = arith.cmpi "slt", %incx, %c0 : index
-    %cond7 = arith.cmpi "slt", %incy, %c0 : index
-    %ix_0 = scf.if %cond6 -> (index) {
-      %tmp = arith.subi %c1, %n : index
-      %ix_1 = arith.muli %tmp, %incx : index
-      scf.yield %ix_1 : index
+    %ix = arith.constant 0 : i32
+    %iy = arith.constant 0 : i32
+    %cond6 = arith.cmpi "slt", %incx, %i0 : i32
+    %cond7 = arith.cmpi "slt", %incy, %i0 : i32
+    %ix_0 = scf.if %cond6 -> (i32) {
+      %tmp = arith.subi %i1, %n : i32
+      %ix_1 = arith.muli %tmp, %incx : i32
+      scf.yield %ix_1 : i32
     } else {
-      scf.yield %ix : index
+      scf.yield %ix : i32
     }
-    %iy_0 = scf.if %cond7 -> (index) {
-      %tmp = arith.subi %c1, %n : index
-      %iy_1 = arith.muli %tmp, %incy : index
-      scf.yield %iy_1 : index
+    %iy_0 = scf.if %cond7 -> (i32) {
+      %tmp = arith.subi %i1, %n : i32
+      %iy_1 = arith.muli %tmp, %incy : i32
+      scf.yield %iy_1 : i32
     } else{
-      scf.yield %iy : index
+      scf.yield %iy : i32
     }
-    scf.for %i_0 = %c0 to %n step %c1 {
-      %dx_val_0 = memref.load %dx[%ix_0] : memref<?xf32>
-      %dy_val_0 = memref.load %dy[%iy_0] : memref<?xf32>
+
+    %incx_index = arith.index_cast %incx : i32 to index
+    %incy_index = arith.index_cast %incy : i32 to index
+    %ix_0_index = arith.index_cast %ix_0 : i32 to index
+    %iy_0_index = arith.index_cast %iy_0 : i32 to index
+
+    %ix_3, %iy_3 = scf.for %i_0 = %c0 to %n_index step %c1
+    iter_args(%ix_4 = %ix_0_index, %iy_4 = %iy_0_index) -> (index, index){
+      %dx_val_0 = memref.load %dx[%ix_4] : memref<?xf32>
+      %dy_val_0 = memref.load %dy[%iy_4] : memref<?xf32>
       %result_0 = arith.mulf %da, %dx_val_0 : f32
       %new_dy_val_0 = arith.addf %dy_val_0, %result_0 : f32
-      memref.store %new_dy_val_0, %dy[%iy_0] : memref<?xf32>
-      %ix_2 = arith.addi %ix, %incx : index
-      %iy_2 = arith.addi %iy, %incy : index
+      memref.store %new_dy_val_0, %dy[%iy_4] : memref<?xf32>
+      %ix_2 = arith.addi %ix_4, %incx_index : index
+      %iy_2 = arith.addi %iy_4, %incy_index : index
+      scf.yield %ix_2, %iy_2 : index, index
     }
     return
 
@@ -84,12 +95,12 @@ func.func @mlir_linpackcdaxpyunrollf32(%n : index, %da : f32, %dx: memref<?xf32>
         memref.store %new_dy_val_1, %dy[%i_1] : memref<?xf32>
       }
     }
-  
-  %cond9 = arith.cmpi "slt", %n, %c4 : index
+
+  %cond9 = arith.cmpi "slt", %n_index, %c4 : index
   cf.cond_br %cond9, ^terminator, ^continue4
 
   ^continue4:
-    scf.for %i_2 = %m to %n step %c4 {
+    scf.for %i_2 = %m to %n_index step %c4 {
       %dx_val_2 = memref.load %dx[%i_2] : memref<?xf32>
       %dy_val_2 = memref.load %dy[%i_2] : memref<?xf32>
       %result_2 = arith.mulf %da, %dx_val_2 : f32

--- a/benchmarks/Vectorization/linpackc/MLIRLinpackCDaxpyUnrollF64.mlir
+++ b/benchmarks/Vectorization/linpackc/MLIRLinpackCDaxpyUnrollF64.mlir
@@ -19,21 +19,24 @@
 //===----------------------------------------------------------------------===//
 
 
-func.func @mlir_linpackcdaxpyunrollf64(%n : index, %da : f64, %dx: memref<?xf64>, %incx : index, 
-                                   %dy: memref<?xf64>, %incy : index) {
+func.func @mlir_linpackcdaxpyunrollf64(%n : i32, %da : f64, %dx: memref<?xf64>, %incx : i32,
+                                   %dy: memref<?xf64>, %incy : i32) {
   %c0 = arith.constant 0 : index
+  %i0 = arith.constant 0 : i32
   %c1 = arith.constant 1 : index
+  %i1 = arith.constant 1 : i32
   %c2 = arith.constant 2 : index
   %c3 = arith.constant 3 : index
   %c4 = arith.constant 4 : index
-  %da_i = arith.fptosi %da : f64 to i64
-  %da_index = arith.index_cast %da_i : i64 to index
-  %m = arith.remui %n, %c4 : index
+  %n_index = arith.index_cast %n : i32 to index
+  %da_i = arith.fptosi %da : f64 to i32
+  %da_index = arith.index_cast %da_i : i32 to index
+  %m = arith.remui %n_index, %c4 : index
 
-  %cond1 = arith.cmpi "sle", %n, %c0 : index
+  %cond1 = arith.cmpi "sle", %n, %i0 : i32
   %cond2 = arith.cmpi "eq", %da_index, %c0 : index
-  %cond3 = arith.cmpi "ne", %incx, %c1 : index
-  %cond4 = arith.cmpi "ne", %incy, %c1 : index
+  %cond3 = arith.cmpi "ne", %incx, %i1 : i32
+  %cond4 = arith.cmpi "ne", %incy, %i1 : i32
   %cond5 = arith.ori %cond3, %cond4 : i1
   
   cf.cond_br %cond1, ^terminator, ^continue0
@@ -44,32 +47,40 @@ func.func @mlir_linpackcdaxpyunrollf64(%n : index, %da : f64, %dx: memref<?xf64>
     cf.cond_br %cond5, ^continue2, ^continue3
 
   ^continue2:
-    %ix = arith.constant 0 : index
-    %iy = arith.constant 0 : index
-    %cond6 = arith.cmpi "slt", %incx, %c0 : index
-    %cond7 = arith.cmpi "slt", %incy, %c0 : index
-    %ix_0 = scf.if %cond6 -> (index) {
-      %tmp = arith.subi %c1, %n : index
-      %ix_1 = arith.muli %tmp, %incx : index
-      scf.yield %ix_1 : index
+    %ix = arith.constant 0 : i32
+    %iy = arith.constant 0 : i32
+    %cond6 = arith.cmpi "slt", %incx, %i0 : i32
+    %cond7 = arith.cmpi "slt", %incy, %i0 : i32
+    %ix_0 = scf.if %cond6 -> (i32) {
+      %tmp = arith.subi %i1, %n : i32
+      %ix_1 = arith.muli %tmp, %incx : i32
+      scf.yield %ix_1 : i32
     } else {
-      scf.yield %ix : index
+      scf.yield %ix : i32
     }
-    %iy_0 = scf.if %cond7 -> (index) {
-      %tmp = arith.subi %c1, %n : index
-      %iy_1 = arith.muli %tmp, %incy : index
-      scf.yield %iy_1 : index
+    %iy_0 = scf.if %cond7 -> (i32) {
+      %tmp = arith.subi %i1, %n : i32
+      %iy_1 = arith.muli %tmp, %incy : i32
+      scf.yield %iy_1 : i32
     } else{
-      scf.yield %iy : index
+      scf.yield %iy : i32
     }
-    scf.for %i_0 = %c0 to %n step %c1 {
-      %dx_val_0 = memref.load %dx[%ix_0] : memref<?xf64>
-      %dy_val_0 = memref.load %dy[%iy_0] : memref<?xf64>
+
+    %incx_index = arith.index_cast %incx : i32 to index
+    %incy_index = arith.index_cast %incy : i32 to index
+    %ix_0_index = arith.index_cast %ix_0 : i32 to index
+    %iy_0_index = arith.index_cast %iy_0 : i32 to index
+
+    %ix_3, %iy_3 = scf.for %i_0 = %c0 to %n_index step %c1
+    iter_args(%ix_4 = %ix_0_index, %iy_4 = %iy_0_index) -> (index, index){
+      %dx_val_0 = memref.load %dx[%ix_4] : memref<?xf64>
+      %dy_val_0 = memref.load %dy[%iy_4] : memref<?xf64>
       %result_0 = arith.mulf %da, %dx_val_0 : f64
       %new_dy_val_0 = arith.addf %dy_val_0, %result_0 : f64
-      memref.store %new_dy_val_0, %dy[%iy_0] : memref<?xf64>
-      %ix_2 = arith.addi %ix, %incx : index
-      %iy_2 = arith.addi %iy, %incy : index
+      memref.store %new_dy_val_0, %dy[%iy_4] : memref<?xf64>
+      %ix_2 = arith.addi %ix_4, %incx_index : index
+      %iy_2 = arith.addi %iy_4, %incy_index : index
+      scf.yield %ix_2, %iy_2 : index, index
     }
     return
 
@@ -85,11 +96,11 @@ func.func @mlir_linpackcdaxpyunrollf64(%n : index, %da : f64, %dx: memref<?xf64>
       }
     }
 
-  %cond9 = arith.cmpi "slt", %n, %c4 : index
+  %cond9 = arith.cmpi "slt", %n_index, %c4 : index
   cf.cond_br %cond9, ^terminator, ^continue4
 
   ^continue4:
-    scf.for %i_2 = %m to %n step %c4 {
+    scf.for %i_2 = %m to %n_index step %c4 {
       %dx_val_2 = memref.load %dx[%i_2] : memref<?xf64>
       %dy_val_2 = memref.load %dy[%i_2] : memref<?xf64>
       %result_2 = arith.mulf %da, %dx_val_2 : f64
@@ -118,7 +129,7 @@ func.func @mlir_linpackcdaxpyunrollf64(%n : index, %da : f64, %dx: memref<?xf64>
       memref.store %new_dy_val_5, %dy[%i_2_3] : memref<?xf64>
     }
     return
-    
+
   ^terminator:
     return
 }


### PR DESCRIPTION
Considering that incx and incy of daxpy function are negative and greater than 1, modify this patch