### PR TITLE
[OpOptimization]add dynamo matmul benchmark

### DIFF
--- a/benchmarks/OpOptimization/MatMul/TorchDynamo/main.py
+++ b/benchmarks/OpOptimization/MatMul/TorchDynamo/main.py
@@ -1,0 +1,110 @@
+import numpy
+import time
+from torchDynamo import *
+# ------------------------------------------------------------------------------
+# User Configurable Variables
+# ------------------------------------------------------------------------------
+
+# Define the size of the matrix.
+# (M, K) x (K, N)
+M = 4
+N = 4
+K = 4
+
+dtype = "float32"
+
+
+# ------------------------------------------------------------------------------
+# Helper Function
+# ------------------------------------------------------------------------------
+
+def evaluator(s, inputs, num):
+  a, b = inputs
+  result = s(a, b)  #warm up
+  all_time = []
+  for i in range(num):
+      torch.cuda.synchronize()
+      start = time.time()
+      result = s(a, b)
+      torch.cuda.synchronize()
+      end = time.time()
+      elapsed_time = end - start
+      all_time.append(elapsed_time)
+
+  # 计算时间的平均值
+  average_time = sum(all_time) / num
+
+  return average_time
+
+
+def evaluate_operation(s, inputs, optimization, log):
+  """Evaluate operation correctness and print the performance information.
+  Args:
+    s: The schedule to be built.
+    inputs: The input tensors.
+    optimization: The name of the optimization.
+    log: The log list.
+  """
+  mean_time = evaluator(s, inputs, 10)
+  log.append((optimization, mean_time))
+
+
+def report_performance(log):
+  """Convert the log into a performance table.
+  Args:
+    log: The log list.
+  """
+  baseline = log[0][1]
+  header = "Benchmark".ljust(20) + "\t" + "Time".rjust(
+      10) + "\t" + "SpeedUp".rjust(10)
+  split_line = "-" * 50
+  print(split_line)
+  print(header)
+  print(split_line)
+  for result in log:
+    formatted_time = "{:.2f}".format(result[1])
+    formatted_performance = "{:.2f}".format(baseline / result[1])
+    print("\033[32m%s\033[0m\t\033[33m%s\033[0m\t\033[34m%s\033[0m" %
+          (result[0].ljust(20), str(formatted_time + " ms").rjust(10),
+           str(formatted_performance).rjust(10)))
+
+
+def main():
+  # ----------------------------------------------------------------------------
+  # Initialization and Baseline
+  # ----------------------------------------------------------------------------
+  # Initialize the log list.
+  log = []
+
+  # Generate random tensor for testing.
+  a_np = numpy.random.rand(M, K)
+  b_np = numpy.random.rand(K, N)
+  a_tensor = torch.tensor(a_np)
+  b_tensor = torch.tensor(b_np)
+
+
+  # ----------------------------------------------------------------------------
+  # Register Benchmarks and Dump Report
+  # ----------------------------------------------------------------------------
+  # Register default schedule.
+
+  s = default_matrix_multiply()
+  evaluate_operation(s,
+                     inputs=(a_tensor, b_tensor),
+                     optimization="torch_default",
+                     log=log)
+
+
+  s = dynamo_matrix_multiply()
+  evaluate_operation(s,
+                     inputs=(a_tensor, b_tensor),
+                     optimization="torch_dynamo",
+                     log=log)
+
+ 
+
+  report_performance(log)
+
+
+if __name__ == "__main__":
+  main()

--- a/benchmarks/OpOptimization/MatMul/TorchDynamo/main.py
+++ b/benchmarks/OpOptimization/MatMul/TorchDynamo/main.py
@@ -31,7 +31,6 @@ def evaluator(s, inputs, num):
       elapsed_time = end - start
       all_time.append(elapsed_time)
 
-  # 计算时间的平均值
   average_time = sum(all_time) / num
 
   return average_time

--- a/benchmarks/OpOptimization/MatMul/TorchDynamo/main.py
+++ b/benchmarks/OpOptimization/MatMul/TorchDynamo/main.py
@@ -11,8 +11,8 @@
 # ===---------------------------------------------------------------------------
 #
 # This file implements the dynamo entry for benchmark Matmul on GPU.
-# torchdynamo is an internal API that uses a CPython feature called the Frame Evaluation 
-# API to safely capture PyTorch graphs. Methods that are available externally for PyTorch 
+# torchdynamo is an internal API that uses a CPython feature called the Frame Evaluation
+# API to safely capture PyTorch graphs. Methods that are available externally for PyTorch
 # users are surfaced through the torch.compiler namespace.
 # which can automatically generate search spaces for optimizing tensor expressions.
 # See the pytorch license at: https://github.com/pytorch/pytorch/blob/main/LICENSE
@@ -21,6 +21,7 @@
 import numpy
 import time
 from torchDynamo import *
+
 # ------------------------------------------------------------------------------
 # User Configurable Variables
 # ------------------------------------------------------------------------------
@@ -31,83 +32,92 @@ N = 4
 K = 4
 dtype = "float32"
 
+
 # ------------------------------------------------------------------------------
 # Helper Function
 # ------------------------------------------------------------------------------
 def evaluator(s, inputs, num):
-  a, b = inputs
-  result = s(a, b)  #warm up
-  all_time = []
-  for i in range(num):
-      torch.cuda.synchronize()
-      start = time.time()
-      result = s(a, b)
-      torch.cuda.synchronize()
-      end = time.time()
-      elapsed_time = end - start
-      all_time.append(elapsed_time)
+    a, b = inputs
+    result = s(a, b)  # warm up
+    all_time = []
+    for i in range(num):
+        torch.cuda.synchronize()
+        start = time.time()
+        result = s(a, b)
+        torch.cuda.synchronize()
+        end = time.time()
+        elapsed_time = end - start
+        all_time.append(elapsed_time)
 
-  average_time = sum(all_time) / num
-  return average_time
+    average_time = sum(all_time) / num
+    return average_time
+
 
 def evaluate_operation(s, inputs, optimization, log):
-  """Evaluate operation correctness and print the performance information.
-  Args:
-    s: The schedule to be built.
-    inputs: The input tensors.
-    optimization: The name of the optimization.
-    log: The log list.
-  """
-  mean_time = evaluator(s, inputs, 10)
-  log.append((optimization, mean_time))
+    """Evaluate operation correctness and print the performance information.
+    Args:
+      s: The schedule to be built.
+      inputs: The input tensors.
+      optimization: The name of the optimization.
+      log: The log list.
+    """
+    mean_time = evaluator(s, inputs, 10)
+    log.append((optimization, mean_time))
+
 
 def report_performance(log):
-  """Convert the log into a performance table.
-  Args:
-    log: The log list.
-  """
-  baseline = log[0][1]
-  header = "Benchmark".ljust(20) + "\t" + "Time".rjust(
-      10) + "\t" + "SpeedUp".rjust(10)
-  split_line = "-" * 50
-  print(split_line)
-  print(header)
-  print(split_line)
-  for result in log:
-    formatted_time = "{:.2f}".format(result[1])
-    formatted_performance = "{:.2f}".format(baseline / result[1])
-    print("\033[32m%s\033[0m\t\033[33m%s\033[0m\t\033[34m%s\033[0m" %
-          (result[0].ljust(20), str(formatted_time + " ms").rjust(10),
-           str(formatted_performance).rjust(10)))
+    """Convert the log into a performance table.
+    Args:
+      log: The log list.
+    """
+    baseline = log[0][1]
+    header = (
+        "Benchmark".ljust(20) + "\t" + "Time".rjust(10) + "\t" + "SpeedUp".rjust(10)
+    )
+    split_line = "-" * 50
+    print(split_line)
+    print(header)
+    print(split_line)
+    for result in log:
+        formatted_time = "{:.2f}".format(result[1])
+        formatted_performance = "{:.2f}".format(baseline / result[1])
+        print(
+            "\033[32m%s\033[0m\t\033[33m%s\033[0m\t\033[34m%s\033[0m"
+            % (
+                result[0].ljust(20),
+                str(formatted_time + " ms").rjust(10),
+                str(formatted_performance).rjust(10),
+            )
+        )
+
 
 def main():
-  # ----------------------------------------------------------------------------
-  # Initialization and Baseline
-  # ----------------------------------------------------------------------------
-  # Initialize the log list.
-  log = []
-  # Generate random tensor for testing.
-  a_np = numpy.random.rand(M, K)
-  b_np = numpy.random.rand(K, N)
-  a_tensor = torch.tensor(a_np)
-  b_tensor = torch.tensor(b_np)
-  # ----------------------------------------------------------------------------
-  # Register Benchmarks and Dump Report
-  # ----------------------------------------------------------------------------
-  # Register default schedule.
-  s = default_matrix_multiply()
-  evaluate_operation(s,
-                     inputs=(a_tensor, b_tensor),
-                     optimization="torch_default",
-                     log=log)
+    # ----------------------------------------------------------------------------
+    # Initialization and Baseline
+    # ----------------------------------------------------------------------------
+    # Initialize the log list.
+    log = []
+    # Generate random tensor for testing.
+    a_np = numpy.random.rand(M, K)
+    b_np = numpy.random.rand(K, N)
+    a_tensor = torch.tensor(a_np)
+    b_tensor = torch.tensor(b_np)
+    # ----------------------------------------------------------------------------
+    # Register Benchmarks and Dump Report
+    # ----------------------------------------------------------------------------
+    # Register default schedule.
+    s = default_matrix_multiply()
+    evaluate_operation(
+        s, inputs=(a_tensor, b_tensor), optimization="torch_default", log=log
+    )
 
-  s = dynamo_matrix_multiply()
-  evaluate_operation(s,
-                     inputs=(a_tensor, b_tensor),
-                     optimization="torch_dynamo",
-                     log=log)
+    s = dynamo_matrix_multiply()
+    evaluate_operation(
+        s, inputs=(a_tensor, b_tensor), optimization="torch_dynamo", log=log
+    )
 
-  report_performance(log)
+    report_performance(log)
+
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/benchmarks/OpOptimization/MatMul/TorchDynamo/main.py
+++ b/benchmarks/OpOptimization/MatMul/TorchDynamo/main.py
@@ -1,6 +1,10 @@
+# ===- matmul.py --------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/pytorch/pytorch/blob/main/LICENSE
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/benchmarks/OpOptimization/MatMul/TorchDynamo/main.py
+++ b/benchmarks/OpOptimization/MatMul/TorchDynamo/main.py
@@ -10,7 +10,7 @@
 #
 # ===---------------------------------------------------------------------------
 #
-# This file implements the dynamo optimization for benchmark Matmul on GPU.
+# This file implements the dynamo entry for benchmark Matmul on GPU.
 # torchdynamo is an internal API that uses a CPython feature called the Frame Evaluation 
 # API to safely capture PyTorch graphs. Methods that are available externally for PyTorch 
 # users are surfaced through the torch.compiler namespace.

--- a/benchmarks/OpOptimization/MatMul/TorchDynamo/main.py
+++ b/benchmarks/OpOptimization/MatMul/TorchDynamo/main.py
@@ -1,4 +1,4 @@
-# ===- matmul.py --------------------------------------------------------
+# ===- matmul.py ---------------------------------------------------------------
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/benchmarks/OpOptimization/MatMul/TorchDynamo/main.py
+++ b/benchmarks/OpOptimization/MatMul/TorchDynamo/main.py
@@ -1,23 +1,39 @@
+# You may obtain a copy of the License at
+#
+#     https://github.com/pytorch/pytorch/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ===---------------------------------------------------------------------------
+#
+# This file implements the dynamo optimization for benchmark Matmul on GPU.
+# torchdynamo is an internal API that uses a CPython feature called the Frame Evaluation 
+# API to safely capture PyTorch graphs. Methods that are available externally for PyTorch 
+# users are surfaced through the torch.compiler namespace.
+# which can automatically generate search spaces for optimizing tensor expressions.
+# See the pytorch license at: https://github.com/pytorch/pytorch/blob/main/LICENSE
+#
+# ===---------------------------------------------------------------------------
 import numpy
 import time
 from torchDynamo import *
 # ------------------------------------------------------------------------------
 # User Configurable Variables
 # ------------------------------------------------------------------------------
-
 # Define the size of the matrix.
 # (M, K) x (K, N)
 M = 4
 N = 4
 K = 4
-
 dtype = "float32"
-
 
 # ------------------------------------------------------------------------------
 # Helper Function
 # ------------------------------------------------------------------------------
-
 def evaluator(s, inputs, num):
   a, b = inputs
   result = s(a, b)  #warm up
@@ -32,9 +48,7 @@ def evaluator(s, inputs, num):
       all_time.append(elapsed_time)
 
   average_time = sum(all_time) / num
-
   return average_time
-
 
 def evaluate_operation(s, inputs, optimization, log):
   """Evaluate operation correctness and print the performance information.
@@ -46,7 +60,6 @@ def evaluate_operation(s, inputs, optimization, log):
   """
   mean_time = evaluator(s, inputs, 10)
   log.append((optimization, mean_time))
-
 
 def report_performance(log):
   """Convert the log into a performance table.
@@ -67,32 +80,26 @@ def report_performance(log):
           (result[0].ljust(20), str(formatted_time + " ms").rjust(10),
            str(formatted_performance).rjust(10)))
 
-
 def main():
   # ----------------------------------------------------------------------------
   # Initialization and Baseline
   # ----------------------------------------------------------------------------
   # Initialize the log list.
   log = []
-
   # Generate random tensor for testing.
   a_np = numpy.random.rand(M, K)
   b_np = numpy.random.rand(K, N)
   a_tensor = torch.tensor(a_np)
   b_tensor = torch.tensor(b_np)
-
-
   # ----------------------------------------------------------------------------
   # Register Benchmarks and Dump Report
   # ----------------------------------------------------------------------------
   # Register default schedule.
-
   s = default_matrix_multiply()
   evaluate_operation(s,
                      inputs=(a_tensor, b_tensor),
                      optimization="torch_default",
                      log=log)
-
 
   s = dynamo_matrix_multiply()
   evaluate_operation(s,
@@ -100,10 +107,7 @@ def main():
                      optimization="torch_dynamo",
                      log=log)
 
- 
-
   report_performance(log)
-
 
 if __name__ == "__main__":
   main()

--- a/benchmarks/OpOptimization/MatMul/TorchDynamo/torchDynamo.py
+++ b/benchmarks/OpOptimization/MatMul/TorchDynamo/torchDynamo.py
@@ -1,43 +1,47 @@
+# You may obtain a copy of the License at
+#
+#     https://github.com/pytorch/pytorch/blob/main/LICENSE
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ===---------------------------------------------------------------------------
+#
+# This file implements the dynamo optimization for benchmark Matmul on GPU.
+# torchdynamo is an internal API that uses a CPython feature called the Frame Evaluation 
+# API to safely capture PyTorch graphs. Methods that are available externally for PyTorch 
+# users are surfaced through the torch.compiler namespace.
+# which can automatically generate search spaces for optimizing tensor expressions.
+# See the pytorch license at: https://github.com/pytorch/pytorch/blob/main/LICENSE
+#
+# ===---------------------------------------------------------------------------
 import torch
-
 
 def matrix_multiply(matrix1, matrix2):
     m, n = matrix1.size()
     n, p = matrix2.size()
     result = torch.zeros(m, p)
-    
     for i in range(m):
         for j in range(p):
             for k in range(n):
                 result[i][j] += matrix1[i][k] * matrix2[k][j]
-    
     return result
-
 
 def default_matrix_multiply():
     def inner_matrix_multiply(matrix1, matrix2):
         m, n = matrix1.size()
         n, p = matrix2.size()
         result = torch.zeros(m, p)
-        
         for i in range(m):
             for j in range(p):
                 for k in range(n):
                     result[i][j] += matrix1[i][k] * matrix2[k][j]
-        
         return result
     return inner_matrix_multiply
-
-
-
 
 def dynamo_matrix_multiply():
     compiled_mm = torch.compile(matrix_multiply,mode="max-autotune")
     return compiled_mm
-
-
-
-
-
-
-

--- a/benchmarks/OpOptimization/MatMul/TorchDynamo/torchDynamo.py
+++ b/benchmarks/OpOptimization/MatMul/TorchDynamo/torchDynamo.py
@@ -1,6 +1,10 @@
+# ===- matmul.py --------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://github.com/pytorch/pytorch/blob/main/LICENSE
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/benchmarks/OpOptimization/MatMul/TorchDynamo/torchDynamo.py
+++ b/benchmarks/OpOptimization/MatMul/TorchDynamo/torchDynamo.py
@@ -1,4 +1,4 @@
-# ===- torchDynamo.py --------------------------------------------------------
+# ===- torchDynamo.py ----------------------------------------------------------
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/benchmarks/OpOptimization/MatMul/TorchDynamo/torchDynamo.py
+++ b/benchmarks/OpOptimization/MatMul/TorchDynamo/torchDynamo.py
@@ -32,7 +32,6 @@ def default_matrix_multiply():
 
 
 def dynamo_matrix_multiply():
-    # compiled_mm = torch.compile(matrix_multiply, backend="inductor")
     compiled_mm = torch.compile(matrix_multiply,mode="max-autotune")
     return compiled_mm
 

--- a/benchmarks/OpOptimization/MatMul/TorchDynamo/torchDynamo.py
+++ b/benchmarks/OpOptimization/MatMul/TorchDynamo/torchDynamo.py
@@ -11,14 +11,15 @@
 # ===---------------------------------------------------------------------------
 #
 # This file implements the dynamo optimization for benchmark Matmul on GPU.
-# torchdynamo is an internal API that uses a CPython feature called the Frame Evaluation 
-# API to safely capture PyTorch graphs. Methods that are available externally for PyTorch 
+# torchdynamo is an internal API that uses a CPython feature called the Frame Evaluation
+# API to safely capture PyTorch graphs. Methods that are available externally for PyTorch
 # users are surfaced through the torch.compiler namespace.
 # which can automatically generate search spaces for optimizing tensor expressions.
 # See the pytorch license at: https://github.com/pytorch/pytorch/blob/main/LICENSE
 #
 # ===---------------------------------------------------------------------------
 import torch
+
 
 def matrix_multiply(matrix1, matrix2):
     m, n = matrix1.size()
@@ -30,6 +31,7 @@ def matrix_multiply(matrix1, matrix2):
                 result[i][j] += matrix1[i][k] * matrix2[k][j]
     return result
 
+
 def default_matrix_multiply():
     def inner_matrix_multiply(matrix1, matrix2):
         m, n = matrix1.size()
@@ -40,8 +42,10 @@ def default_matrix_multiply():
                 for k in range(n):
                     result[i][j] += matrix1[i][k] * matrix2[k][j]
         return result
+
     return inner_matrix_multiply
 
+
 def dynamo_matrix_multiply():
-    compiled_mm = torch.compile(matrix_multiply,mode="max-autotune")
+    compiled_mm = torch.compile(matrix_multiply, mode="max-autotune")
     return compiled_mm

--- a/benchmarks/OpOptimization/MatMul/TorchDynamo/torchDynamo.py
+++ b/benchmarks/OpOptimization/MatMul/TorchDynamo/torchDynamo.py
@@ -1,0 +1,44 @@
+import torch
+
+
+def matrix_multiply(matrix1, matrix2):
+    m, n = matrix1.size()
+    n, p = matrix2.size()
+    result = torch.zeros(m, p)
+    
+    for i in range(m):
+        for j in range(p):
+            for k in range(n):
+                result[i][j] += matrix1[i][k] * matrix2[k][j]
+    
+    return result
+
+
+def default_matrix_multiply():
+    def inner_matrix_multiply(matrix1, matrix2):
+        m, n = matrix1.size()
+        n, p = matrix2.size()
+        result = torch.zeros(m, p)
+        
+        for i in range(m):
+            for j in range(p):
+                for k in range(n):
+                    result[i][j] += matrix1[i][k] * matrix2[k][j]
+        
+        return result
+    return inner_matrix_multiply
+
+
+
+
+def dynamo_matrix_multiply():
+    # compiled_mm = torch.compile(matrix_multiply, backend="inductor")
+    compiled_mm = torch.compile(matrix_multiply,mode="max-autotune")
+    return compiled_mm
+
+
+
+
+
+
+

--- a/benchmarks/OpOptimization/MatMul/TorchDynamo/torchDynamo.py
+++ b/benchmarks/OpOptimization/MatMul/TorchDynamo/torchDynamo.py
@@ -1,4 +1,4 @@
-# ===- matmul.py --------------------------------------------------------
+# ===- torchDynamo.py --------------------------------------------------------
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
When evaluating the performance of Torch's Dynamo, I encountered the following issues:

-  Initially, I observed negative optimization results. However, I later discovered that adding warm-up in the evaluator resulted in positive optimization.

- I was unable to run the CPU version, even after moving the tensor to the CPU.

- When dealing with slightly larger matrices, I encountered bugs that prevented successful compilation. [This issue](https://github.com/pytorch/pytorch/issues/97361) has also been reported by others in the PyTorch repository. As of last month, the community had not provided a solution.



![image](https://github.com/buddy-compiler/buddy-benchmark/assets/62176674/e729a22d-e973-43b3-9115-11187b0df933)

