### PR TITLE
[DAP] Add test cases for SIMD version iir operation. 

### DIFF
--- a/benchmarks/AudioProcessing/BuddyIirBenchmark.cpp
+++ b/benchmarks/AudioProcessing/BuddyIirBenchmark.cpp
@@ -18,8 +18,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <buddy/Core/Container.h>
 #include <benchmark/benchmark.h>
+#include <buddy/Core/Container.h>
 #include <kfr/base.hpp>
 #include <kfr/dft.hpp>
 #include <kfr/dsp.hpp>
@@ -29,35 +29,43 @@ using namespace kfr;
 
 // Declare the IIR C interface.
 extern "C" {
-void _mlir_ciface_mlir_iir(MemRef<float, 1> *inputBuddyConv1D,
-                           MemRef<float, 2> *kernelBuddyConv1D,
-                           MemRef<float, 1> *outputBuddyConv1D);
+void _mlir_ciface_mlir_iir(MemRef<double, 1> *inputBuddyConv1D,
+                           MemRef<double, 2> *kernelBuddyConv1D,
+                           MemRef<double, 1> *outputBuddyConv1D);
 
-void _mlir_ciface_buddy_iir(MemRef<float, 1> *inputBuddyConv1D,
-                            MemRef<float, 2> *kernelBuddyConv1D,
-                            MemRef<float, 1> *outputBuddyConv1D);
+void _mlir_ciface_mlir_iir_simd(MemRef<double, 1> *inputBuddyConv1D,
+                                MemRef<double, 2> *kernelBuddyConv1D,
+                                MemRef<double, 1> *outputBuddyConv1D);
+
+void _mlir_ciface_buddy_iir(MemRef<double, 1> *inputBuddyConv1D,
+                            MemRef<double, 2> *kernelBuddyConv1D,
+                            MemRef<double, 1> *outputBuddyConv1D);
+
+void _mlir_ciface_buddy_iir_simd(MemRef<double, 1> *inputBuddyConv1D,
+                                 MemRef<double, 2> *kernelBuddyConv1D,
+                                 MemRef<double, 1> *outputBuddyConv1D);
 }
 
 namespace {
-univector<float> kernel;
-zpk<fbase> filt = iir_lowpass(bessel<fbase>(24), 1000, 48000);
-std::vector<biquad_params<fbase>> bqs = to_sos(filt);
+univector<double> kernel;
+zpk<double> filt = iir_lowpass(bessel<double>(24), 1000, 48000);
+std::vector<biquad_params<double>> bqs = to_sos(filt);
 
-univector<float, 2000000> aud_buddy_iir;
-univector<float, 2000000> result_buddy_iir;
+univector<double, 2000000> aud_buddy_iir;
+univector<double, 2000000> result_buddy_iir;
 intptr_t size_f = bqs.size();
 intptr_t sizeofKernel[2] = {size_f, 6};
 intptr_t sizeofAud{aud_buddy_iir.size()};
 
 // MemRef copys all data, so data here are actually not accessed.
-MemRef<float, 2> kernelRef(sizeofKernel);
-MemRef<float, 1> audRef(&sizeofAud);
-MemRef<float, 1> resRef(&sizeofAud);
+MemRef<double, 2> kernelRef(sizeofKernel);
+MemRef<double, 1> audRef(&sizeofAud);
+MemRef<double, 1> resRef(&sizeofAud);
 } // namespace
 
 // Initialize univector.
 void initializeBuddyIir() {
-  audio_reader_wav<float> reader(open_file_for_reading(
+  audio_reader_wav<double> reader(open_file_for_reading(
       "../../benchmarks/AudioProcessing/Audios/NASA_Mars.wav"));
   reader.read(aud_buddy_iir.data(), aud_buddy_iir.size());
 
@@ -71,9 +79,9 @@ void initializeBuddyIir() {
     kernel.push_back(bq.a2);
   }
 
-  kernelRef = std::move(MemRef<float, 2>(kernel.data(), sizeofKernel));
-  audRef = std::move(MemRef<float, 1>(aud_buddy_iir.data(), &sizeofAud));
-  resRef = std::move(MemRef<float, 1>(&sizeofAud));
+  kernelRef = std::move(MemRef<double, 2>(kernel.data(), sizeofKernel));
+  audRef = std::move(MemRef<double, 1>(aud_buddy_iir.data(), &sizeofAud));
+  resRef = std::move(MemRef<double, 1>(&sizeofAud));
 }
 
 // Benchmarking function.
@@ -81,6 +89,15 @@ static void MLIR_IIR(benchmark::State &state) {
   for (auto _ : state) {
     for (int i = 0; i < state.range(0); ++i) {
       _mlir_ciface_mlir_iir(&audRef, &kernelRef, &resRef);
+    }
+  }
+}
+
+// Benchmarking function.
+static void MLIR_IIR_SIMD(benchmark::State &state) {
+  for (auto _ : state) {
+    for (int i = 0; i < state.range(0); ++i) {
+      _mlir_ciface_mlir_iir_simd(&audRef, &kernelRef, &resRef);
     }
   }
 }
@@ -94,21 +111,41 @@ static void BUDDY_IIR(benchmark::State &state) {
   }
 }
 
+// Benchmarking function.
+static void BUDDY_IIR_SIMD(benchmark::State &state) {
+  for (auto _ : state) {
+    for (int i = 0; i < state.range(0); ++i) {
+      _mlir_ciface_buddy_iir_simd(&audRef, &kernelRef, &resRef);
+    }
+  }
+}
+
 // Register benchmarking function.
 BENCHMARK(MLIR_IIR)->Arg(1)->Unit(benchmark::kMillisecond);
+BENCHMARK(MLIR_IIR_SIMD)->Arg(1)->Unit(benchmark::kMillisecond);
 BENCHMARK(BUDDY_IIR)->Arg(1)->Unit(benchmark::kMillisecond);
+BENCHMARK(BUDDY_IIR_SIMD)->Arg(1)->Unit(benchmark::kMillisecond);
 
 // Generate result_buddy_iir wav file.
 void generateResultBuddyIir() {
   println("-------------------------------------------------------");
   println("[ Buddy IIR Result Information ]");
-  MemRef<float, 1> generateResult(&sizeofAud);
+  MemRef<double, 1> generateResult(&sizeofAud);
+
   _mlir_ciface_buddy_iir(&audRef, &kernelRef, &generateResult);
 
-  audio_writer_wav<float> writer(open_file_for_writing("./ResultBuddyIir.wav"),
-                                 audio_format{1 /* channel */,
-                                              audio_sample_type::i24,
-                                              100000 /* sample rate */});
+  // TODO : Move data printing to the validation PR.
+  // print output for the first 100 ouputs
+  for (int i = 0; i < 100; ++i) {
+    std::cout << " " << generateResult[i];
+    if (i % 10 == 9)
+      std::cout << "\n";
+  }
+
+  audio_writer_wav<double> writer(open_file_for_writing("./ResultBuddyIir.wav"),
+                                  audio_format{1 /* channel */,
+                                               audio_sample_type::i24,
+                                               100000 /* sample rate */});
   writer.write(generateResult.getData(), generateResult.getSize());
   println("Sample Rate  = ", writer.format().samplerate);
   println("Channels     = ", writer.format().channels);

--- a/benchmarks/AudioProcessing/CMakeLists.txt
+++ b/benchmarks/AudioProcessing/CMakeLists.txt
@@ -75,6 +75,32 @@ add_custom_command(OUTPUT mlir-iir.o
         )
 add_library(MLIRIir STATIC mlir-iir.o)
 set_target_properties(MLIRIir PROPERTIES LINKER_LANGUAGE CXX)
+
+#-------------------------------------------------------------------------------
+# MLIR IIR SIMD Operation
+#-------------------------------------------------------------------------------
+
+# Support only when num{SOS matrix} <= 16. 
+# The dap.iir_simd operation implemented in buddy-mlir project will support num{SOS matrix} <= 64/
+add_custom_command(OUTPUT mlir-iir-simd.o
+        COMMAND ${BUDDY_MLIR_BUILD_DIR}/bin/buddy-opt
+        ${BUDDY_SOURCE_DIR}/benchmarks/AudioProcessing/MLIRIirSimd.mlir
+        -lower-dap="DAP-vector-splitting=64" -convert-linalg-to-affine-loops
+        -lower-affine
+        -convert-scf-to-cf 
+        -convert-vector-to-llvm 
+        --llvm-request-c-wrappers
+        -convert-arith-to-llvm
+        -finalize-memref-to-llvm -convert-func-to-llvm
+        -reconcile-unrealized-casts |
+        ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
+        ${LLVM_MLIR_BINARY_DIR}/llc -mtriple=${BUDDY_OPT_TRIPLE} 
+            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
+            -o ${BUDDY_BINARY_DIR}/../benchmarks/AudioProcessing/mlir-iir-simd.o
+        )
+add_library(MLIRIirSimd STATIC mlir-iir-simd.o)
+set_target_properties(MLIRIirSimd PROPERTIES LINKER_LANGUAGE CXX)
+
 add_executable(audio-processing-benchmark
   KFRFft.cpp
   KFRIir.cpp
@@ -96,6 +122,7 @@ target_link_libraries(audio-processing-benchmark
   kfr_dft
   MLIRBiquad
   MLIRIir
+  MLIRIirSimd
   BuddyLibDAP
   GoogleBenchmark
 )

--- a/benchmarks/AudioProcessing/MLIRIir.mlir
+++ b/benchmarks/AudioProcessing/MLIRIir.mlir
@@ -1,4 +1,5 @@
-//===- BuddyIir.mlir ------------------------------------------------------===//
+//===- MLIRIir.mlir -------------------------------------------------------===//
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,38 +19,37 @@
 //
 //===----------------------------------------------------------------------===//
 
-func.func @mlir_iir(%in : memref<?xf32>, %filter : memref<?x?xf32>, %out : memref<?xf32>){
+func.func @mlir_iir(%in : memref<?xf64>, %filter : memref<?x?xf64>, %out : memref<?xf64>){
   %c0 = arith.constant 0 : index
-  %N = memref.dim %in, %c0 : memref<?xf32>
-  %M = memref.dim %filter, %c0: memref<?x?xf32>
+  %N = memref.dim %in, %c0 : memref<?xf64>
+  %M = memref.dim %filter, %c0: memref<?x?xf64>
 
-  affine.for %j = 0 to %M iter_args(%inpt = %in) -> (memref<?xf32>){
-    %b0 = affine.load %filter[%j, 0] : memref<?x?xf32>
-    %b1 = affine.load %filter[%j, 1] : memref<?x?xf32>
-    %b2 = affine.load %filter[%j, 2] : memref<?x?xf32>
-    %a0 = affine.load %filter[%j, 3] : memref<?x?xf32>
-    %a1 = affine.load %filter[%j, 4] : memref<?x?xf32>
-    %a2 = affine.load %filter[%j, 5] : memref<?x?xf32>
-    %init_z1 = arith.constant 0.0 : f32
-    %init_z2 = arith.constant 0.0 : f32
-    %res:2 = affine.for %i = 0 to %N iter_args(%z1 = %init_z1, %z2 = %init_z2) -> (f32, f32) {
-        %input = affine.load %inpt[%i] : memref<?xf32>
-        %t0 = arith.mulf %b0, %input : f32
-        %output = arith.addf %t0, %z1 : f32
+  affine.for %j = 0 to %M iter_args(%inpt = %in) -> (memref<?xf64>){
+    %b0 = affine.load %filter[%j, 0] : memref<?x?xf64>
+    %b1 = affine.load %filter[%j, 1] : memref<?x?xf64>
+    %b2 = affine.load %filter[%j, 2] : memref<?x?xf64>
+    %a1 = affine.load %filter[%j, 4] : memref<?x?xf64>
+    %a2 = affine.load %filter[%j, 5] : memref<?x?xf64>
+    %init_z1 = arith.constant 0.0 : f64
+    %init_z2 = arith.constant 0.0 : f64
+    %res:2 = affine.for %i = 0 to %N iter_args(%z1 = %init_z1, %z2 = %init_z2) -> (f64, f64) {
+        %input = affine.load %inpt[%i] : memref<?xf64>
+        %t0 = arith.mulf %b0, %input : f64
+        %output = arith.addf %t0, %z1 : f64
 
-        %t1 = arith.mulf %b1, %input : f32
-        %t2 = arith.mulf %a1, %output : f32
-        %t3 = arith.subf %t1, %t2 : f32
-        %z1_next = arith.addf %z2, %t3 : f32
+        %t1 = arith.mulf %b1, %input : f64
+        %t2 = arith.mulf %a1, %output : f64
+        %t3 = arith.subf %t1, %t2 : f64
+        %z1_next = arith.addf %z2, %t3 : f64
 
-        %t4 = arith.mulf %b2, %input : f32
-        %t5 = arith.mulf %a2, %output : f32
-        %z2_next = arith.subf %t4, %t5 : f32
+        %t4 = arith.mulf %b2, %input : f64
+        %t5 = arith.mulf %a2, %output : f64
+        %z2_next = arith.subf %t4, %t5 : f64
         
-        affine.store %output, %out[%i] : memref<?xf32>
-        affine.yield %z1_next, %z2_next : f32, f32
+        affine.store %output, %out[%i] : memref<?xf64>
+        affine.yield %z1_next, %z2_next : f64, f64
     }
-    affine.yield %out : memref<?xf32>
+    affine.yield %out : memref<?xf64>
   }
   return
 }

--- a/benchmarks/AudioProcessing/MLIRIirSimd.mlir
+++ b/benchmarks/AudioProcessing/MLIRIirSimd.mlir
@@ -1,0 +1,126 @@
+//===- MLIRIirSimd.mlir ---------------------------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides the MLIR IIR SIMD function.
+//
+//===----------------------------------------------------------------------===//
+
+func.func @mlir_iir_simd(%in : memref<?xf64>, %filter : memref<?x?xf64>, %out : memref<?xf64>){
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %N = memref.dim %in, %c0 : memref<?xf64>
+  %M = memref.dim %filter, %c0: memref<?x?xf64>
+
+  %f0 = arith.constant 0.0 : f64
+  %f1 = arith.constant 1.0 : f64
+  %vecA1 = vector.splat %f0 : vector<16xf64>
+  %vecA2 = vector.splat %f0 : vector<16xf64>
+  %vecB0 = vector.splat %f1 : vector<16xf64>
+  %vecB1 = vector.splat %f0 : vector<16xf64>
+  %vecB2 = vector.splat %f0 : vector<16xf64>
+
+  // biquad params distribution stage
+  %B0, %B1, %B2, %A1, %A2 = affine.for %i = 0 to %M iter_args(%vecB0_temp = %vecB0, %vecB1_temp = %vecB1, %vecB2_temp = %vecB2,
+                                    %vecA1_temp = %vecA1, %vecA2_temp = %vecA2) -> 
+                                    (vector<16xf64>, vector<16xf64>, vector<16xf64>, 
+                                    vector<16xf64>, vector<16xf64>){
+    %b0 = affine.load %filter[%i, 0] : memref<?x?xf64>
+    %b1 = affine.load %filter[%i, 1] : memref<?x?xf64>
+    %b2 = affine.load %filter[%i, 2] : memref<?x?xf64>
+    %a1 = affine.load %filter[%i, 4] : memref<?x?xf64>
+    %a2 = affine.load %filter[%i, 5] : memref<?x?xf64>
+
+    %vecB0_next = vector.insertelement %b0, %vecB0_temp[%i : index]: vector<16xf64>
+    %vecB1_next = vector.insertelement %b1, %vecB1_temp[%i : index]: vector<16xf64>
+    %vecB2_next = vector.insertelement %b2, %vecB2_temp[%i : index]: vector<16xf64>
+    %vecA1_next = vector.insertelement %a1, %vecA1_temp[%i : index]: vector<16xf64>
+    %vecA2_next = vector.insertelement %a2, %vecA2_temp[%i : index]: vector<16xf64>
+    
+    affine.yield %vecB0_next, %vecB1_next, %vecB2_next, %vecA1_next, %vecA2_next : vector<16xf64>, vector<16xf64>, vector<16xf64>, vector<16xf64>, vector<16xf64>
+  }
+
+  // %vecIn = vector.splat %f0 : vector<16xf64>
+  %vecOut = vector.splat %f0 : vector<16xf64>
+  %vecS1 = vector.splat %f0 : vector<16xf64>
+  %vecS2 = vector.splat %f0 : vector<16xf64>
+
+  // pipeline injection stage
+  %Out_stage1, %S1_stage1, %S2_stage1 = affine.for %i = 0 to 15 iter_args(%vecIn_temp = %vecOut, %vecS1_temp = %vecS1, 
+                                    %vecS2_temp = %vecS2) -> (vector<16xf64>, vector<16xf64>, 
+                                                              vector<16xf64>){
+    %input = affine.load %in[%i] : memref<?xf64>
+    %vecIn_move_right = vector.shuffle %vecIn_temp, %vecIn_temp[0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14] : vector<16xf64>, vector<16xf64>
+    %vecIn_next = vector.insertelement %input, %vecIn_move_right[%c0 : index]: vector<16xf64>
+    %vecOut_next = vector.fma %B0, %vecIn_next, %vecS1_temp : vector<16xf64>
+
+    %vecS1_part1 = vector.fma %B1, %vecIn_next, %vecS2_temp : vector<16xf64>
+    %vecS1_part2 = arith.mulf %A1, %vecOut_next : vector<16xf64>
+    %vecS1_next = arith.subf %vecS1_part1, %vecS1_part2 : vector<16xf64>
+
+    %vecS2_part1 = arith.mulf %B2, %vecIn_next : vector<16xf64>
+    %vecS2_part2 = arith.mulf %A2, %vecOut_next : vector<16xf64>
+    %vecS2_next = arith.subf %vecS2_part1, %vecS2_part2 : vector<16xf64>
+
+    affine.yield %vecOut_next, %vecS1_next, %vecS2_next : vector<16xf64>, vector<16xf64>, vector<16xf64>
+  }
+
+  %i15 = arith.constant 15 : index
+  %upperbound = arith.subi %N, %i15 : index
+
+  // pipeline process stage
+  %Out_stage2, %S1_stage2, %S2_stage2 = affine.for %i = 0 to %upperbound iter_args(%vecIn_temp = %Out_stage1, %vecS1_temp = %S1_stage1, 
+                                             %vecS2_temp = %S2_stage1) -> (vector<16xf64>, vector<16xf64>, vector<16xf64>){
+    %input = affine.load %in[%i + 15] : memref<?xf64>
+    %vecIn_move_right = vector.shuffle %vecIn_temp, %vecIn_temp[0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14] : vector<16xf64>, vector<16xf64>
+    %vecIn_next = vector.insertelement %input, %vecIn_move_right[%c0 : index]: vector<16xf64>
+    %vecOut_next = vector.fma %B0, %vecIn_next, %vecS1_temp : vector<16xf64>
+    %output = vector.extractelement %vecOut_next[%i15 : index] : vector<16xf64>
+    affine.store %output, %out[%i] : memref<?xf64>
+
+    %vecS1_part1 = vector.fma %B1, %vecIn_next, %vecS2_temp : vector<16xf64>
+    %vecS1_part2 = arith.mulf %A1, %vecOut_next : vector<16xf64>
+    %vecS1_next = arith.subf %vecS1_part1, %vecS1_part2 : vector<16xf64>
+
+    %vecS2_part1 = arith.mulf %B2, %vecIn_next : vector<16xf64>
+    %vecS2_part2 = arith.mulf %A2, %vecOut_next : vector<16xf64>
+    %vecS2_next = arith.subf %vecS2_part1, %vecS2_part2 : vector<16xf64>
+
+    affine.yield %vecOut_next, %vecS1_next, %vecS2_next : vector<16xf64>, vector<16xf64>, vector<16xf64>
+  }
+
+  // pipeline tail ending stage
+  affine.for %i = %upperbound to %N iter_args(%vecIn_temp = %Out_stage2, %vecS1_temp = %S1_stage2, 
+                                              %vecS2_temp = %S2_stage2) -> (vector<16xf64>, vector<16xf64>, 
+                                                                                     vector<16xf64>){
+    %vecIn_move_right = vector.shuffle %vecIn_temp, %vecIn_temp[0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14] : vector<16xf64>, vector<16xf64>
+    %vecIn_next = vector.insertelement %f0, %vecIn_move_right[%c0 : index]: vector<16xf64>
+    %vecOut_next = vector.fma %B0, %vecIn_next, %vecS1_temp : vector<16xf64>
+    %output = vector.extractelement %vecOut_next[%i15 : index] : vector<16xf64>
+    affine.store %output, %out[%i] : memref<?xf64>
+
+    %vecS1_part1 = vector.fma %B1, %vecIn_next, %vecS2_temp : vector<16xf64>
+    %vecS1_part2 = arith.mulf %A1, %vecOut_next : vector<16xf64>
+    %vecS1_next = arith.subf %vecS1_part1, %vecS1_part2 : vector<16xf64>
+
+    %vecS2_part1 = arith.mulf %B2, %vecIn_next : vector<16xf64>
+    %vecS2_part2 = arith.mulf %A2, %vecOut_next : vector<16xf64>
+    %vecS2_next = arith.subf %vecS2_part1, %vecS2_part2 : vector<16xf64>
+    
+    affine.yield %vecOut_next, %vecS1_next, %vecS2_next : vector<16xf64>, vector<16xf64>, vector<16xf64>
+  }
+
+  return
+}


### PR DESCRIPTION
**1. Add hand-written mlir document**
File MLIRIirSimd.mlir is the handwritten mlir for using SIMD in the iir operation.

**2. Change type to f64(double)**
All the type in IIR benchmarks changed to double. Including KFRIir.cpp & BuddyIirBenchmark.cpp.

This PR should check with the PR in buddy-mlir.