### PR TITLE
[Build] Add buddy-mlir workable commit info

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Currently, the image processing benchmark includes the following frameworks or o
 
 *NOTE: Please make sure the `buddy-opt` tool of buddy-mlir project can work well.*
 
+Known to work with commit id `7b2e4474baa5f43322ad55107d9bd1990582929d` of buddy-mlir.
+
 Run the image processing benchmark:
 
 | CMake Options  | Default Value |

--- a/benchmarks/ImageProcessing/MLIRConv2DBenchmark.cpp
+++ b/benchmarks/ImageProcessing/MLIRConv2DBenchmark.cpp
@@ -29,9 +29,9 @@ using namespace std;
 
 // Declare the conv2d C interface.
 extern "C" {
-void _mlir_ciface_mlir_conv_2d(MemRef<float, 2> *inputConv2D,
-                               MemRef<float, 2> *kernelConv2D,
-                               MemRef<float, 2> *outputConv2D);
+void _mlir_ciface_conv_2d(MemRef<float, 2> *inputConv2D,
+                          MemRef<float, 2> *kernelConv2D,
+                          MemRef<float, 2> *outputConv2D);
 }
 
 // Read input image.
@@ -78,8 +78,8 @@ static void MLIR_Conv2D(benchmark::State &state) {
 
   for (auto _ : state) {
     for (int i = 0; i < state.range(0); ++i) {
-      _mlir_ciface_mlir_conv_2d(&inputMLIRConv2D, &kernelMLIRConv2D,
-                                &outputMLIRConv2D);
+      _mlir_ciface_conv_2d(&inputMLIRConv2D, &kernelMLIRConv2D,
+                           &outputMLIRConv2D);
     }
   }
 }
@@ -94,7 +94,7 @@ void generateResultMLIRConv2D() {
   MemRef<float, 2> kernel(kernelDataMLIRConv2D, sizesKernelMLIRConv2D);
   MemRef<float, 2> output(sizesOutputMLIRConv2D);
   // Run the 2D convolution.
-  _mlir_ciface_mlir_conv_2d(&input, &kernel, &output);
+  _mlir_ciface_conv_2d(&input, &kernel, &output);
 
   // Define a cv::Mat with the output of the convolution.
   Mat outputImage(outputRowsMLIRConv2D, outputColsMLIRConv2D, CV_32FC1,


### PR DESCRIPTION
This PR intends to add the correct commit info of `buddy-mlir` with which `image-processing-benchmark` can be built. It also fixes the `MLIRConv2DBenchmark`. 