### PR TITLE
[Op Level] Fix cmakelist legacy of op examples

### DIFF
--- a/benchmarks/DeepLearning/Ops/ArithAddfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/ArithAddfOp/CMakeLists.txt
@@ -1,14 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
-project(ArithAddfBenchmark)
-
-# Define variables for the cross-compilation toolchain and options.
-if (CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
-
 # Add custom commands for scalar implementation of arith.addf
 add_custom_command(OUTPUT addf_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/ArithAddfOp/ArithAddf.mlir |

--- a/benchmarks/DeepLearning/Ops/ArithDivfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/ArithDivfOp/CMakeLists.txt
@@ -1,14 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
-project(ArithDivfBenchmark)
-
-# Define variables for the cross-compilation toolchain and options.
-if (CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
-
 # Add custom commands for scalar implementation of arith.divf
 add_custom_command(OUTPUT divf_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/ArithDivfOp/ArithDivf.mlir |

--- a/benchmarks/DeepLearning/Ops/ArithMulfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/ArithMulfOp/CMakeLists.txt
@@ -1,14 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
-project(ArithMulfBenchmark)
-
-# Define variables for the cross-compilation toolchain and options.
-if (CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
-
 # Add custom commands for scalar implementation of arith.mulf
 add_custom_command(OUTPUT mulf_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/ArithMulfOp/ArithMulf.mlir |

--- a/benchmarks/DeepLearning/Ops/ArithNegfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/ArithNegfOp/CMakeLists.txt
@@ -1,14 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
-project(ArithNegfBenchmark)
-
-# Define variables for the cross-compilation toolchain and options.
-if (CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
-
 # Add custom commands for scalar implementation of arith.negf
 add_custom_command(OUTPUT negf_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/ArithNegfOp/ArithNegf.mlir |

--- a/benchmarks/DeepLearning/Ops/ArithSubfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/ArithSubfOp/CMakeLists.txt
@@ -1,13 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
-project(ArithSubfBenchmark)
-
-# Define variables for the cross-compilation toolchain and options.
-if (CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
 
 # Add custom commands for scalar implementation of arith.subf
 add_custom_command(OUTPUT subf_scalar.o

--- a/benchmarks/DeepLearning/Ops/BatchMatMulOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/BatchMatMulOp/CMakeLists.txt
@@ -1,16 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
-
-project(BatchMatMulBenchmark LANGUAGES CXX C)
-
-set(CMAKE_CXX_STANDARD 14)
-
-if (CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
-
 add_custom_command(OUTPUT batch_matmul_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/BatchMatMulOp/BatchMatMul.mlir |
           sed 's/@batch_matmul/@batch_matmul_scalar/' |

--- a/benchmarks/DeepLearning/Ops/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/CMakeLists.txt
@@ -15,3 +15,4 @@ add_subdirectory(MathExpOp)
 add_subdirectory(ReduceAddfOp)
 add_subdirectory(ReduceMaxfOp)
 add_subdirectory(SoftmaxExpSumDivOp)
+

--- a/benchmarks/DeepLearning/Ops/Conv2DNchwFchwOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/Conv2DNchwFchwOp/CMakeLists.txt
@@ -1,10 +1,3 @@
-if(CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
-
 add_custom_command(OUTPUT conv2d_nchw_fchw-scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/Conv2DNchwFchwOp/Conv2DNchwFchw.mlir |
   sed 's/@conv_2d_nchw_fchw/@conv_2d_nchw_fchw_scalar/' |

--- a/benchmarks/DeepLearning/Ops/DepthwiseConv2DNhwcHwcOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/DepthwiseConv2DNhwcHwcOp/CMakeLists.txt
@@ -1,10 +1,3 @@
-if(CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
-
 add_custom_command(OUTPUT depthwise_conv_2d_nhwc_hwc_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/DepthwiseConv2DNhwcHwcOp/DepthwiseConv2DNhwcHwc.mlir |
   sed 's/@depthwise_conv_2d_nhwc_hwc/@depthwise_conv_2d_nhwc_hwc_scalar/' |

--- a/benchmarks/DeepLearning/Ops/MatMulOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/MatMulOp/CMakeLists.txt
@@ -1,10 +1,3 @@
-if (CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
-
 add_custom_command(OUTPUT matmul-scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/MatMulOp/MatMul.mlir |
           sed 's/bm_matmul/matmul_scalar/' |

--- a/benchmarks/DeepLearning/Ops/MathExpOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/MathExpOp/CMakeLists.txt
@@ -1,14 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
-project(MathExpBenchmark)
-
-# Define variables for the cross-compilation toolchain and options.
-if (CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
-
 # Add custom commands for scalar implementation of math.exp
 add_custom_command(OUTPUT exp_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/MathExpOp/MathExp.mlir |

--- a/benchmarks/DeepLearning/Ops/MathFpowOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/MathFpowOp/CMakeLists.txt
@@ -1,14 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
-project(MathFpowBenchmark)
-
-# Define variables for the cross-compilation toolchain and options.
-if (CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
-
 # Add custom commands for scalar implementation of math.fpow
 add_custom_command(OUTPUT fpow_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/MathFpowOp/MathFpow.mlir |

--- a/benchmarks/DeepLearning/Ops/MathRsqrtOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/MathRsqrtOp/CMakeLists.txt
@@ -1,14 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
-project(MathRsqrtBenchmark)
-
-# Define variables for the cross-compilation toolchain and options.
-if (CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
-
 # Add custom commands for scalar implementation of math.rsqrt
 add_custom_command(OUTPUT rsqrt_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/MathRsqrtOp/MathRsqrt.mlir |

--- a/benchmarks/DeepLearning/Ops/PoolingNhwcSumOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/PoolingNhwcSumOp/CMakeLists.txt
@@ -1,10 +1,3 @@
-if (CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
-
 add_custom_command(OUTPUT pooling_nhwc_sum_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/PoolingNhwcSumOp/PoolingNhwcSum.mlir |
           sed 's/@pooling_nhwc_sum/@pooling_nhwc_sum_scalar/' |

--- a/benchmarks/DeepLearning/Ops/ReduceAddfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/ReduceAddfOp/CMakeLists.txt
@@ -1,14 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
-project(ReduceAddfBenchmark)
-
-# Define variables for the cross-compilation toolchain and options.
-if (CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
-
 # Add custom commands for scalar implementation of reduce.addf
 add_custom_command(OUTPUT addf_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/ReduceAddfOp/ReduceAddf.mlir |

--- a/benchmarks/DeepLearning/Ops/ReduceMaxfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/ReduceMaxfOp/CMakeLists.txt
@@ -1,14 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
-project(ReduceMaxfBenchmark)
-
-# Define variables for the cross-compilation toolchain and options.
-if (CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
-
 # Add custom commands for scalar implementation of reduce.maxf
 add_custom_command(OUTPUT maxf_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/ReduceMaxfOp/ReduceMaxf.mlir |

--- a/benchmarks/DeepLearning/Ops/SoftmaxExpSumDivOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/SoftmaxExpSumDivOp/CMakeLists.txt
@@ -1,10 +1,3 @@
-if (CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
-
 add_custom_command(OUTPUT softmaxexpsumdiv_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/SoftmaxExpSumDivOp/SoftmaxExpSumDiv.mlir |
           sed 's/@softmaxexpsumdiv/@softmaxexpsumdiv_scalar/' |


### PR DESCRIPTION
fix redundant variables for the cross-compilation toolchain and options for op examples