### PR TITLE
[DeepLearning] Update dependencies & replace llc with clang

### DIFF
--- a/benchmarks/DeepLearning/Layers/FFN/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Layers/FFN/CMakeLists.txt
@@ -7,6 +7,8 @@ add_custom_command(
   COMMENT "Generating forward.mlir, subgraph0.mlir"
 )
 
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 add_custom_command(
   OUTPUT forward_scalar.o
   COMMAND
@@ -25,10 +27,10 @@ add_custom_command(
                                 convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
                                 convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
                                 convert-func-to-llvm, reconcile-unrealized-casts)" |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O0
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/forward_scalar.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_scalar.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} forward_scalar.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_scalar.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
@@ -64,10 +66,10 @@ add_custom_command(
       -expand-strided-metadata
       -finalize-memref-to-llvm
       -reconcile-unrealized-casts |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O0
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_scalar.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_scalar.ll
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} subgraph0_scalar.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_scalar.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
@@ -92,10 +94,10 @@ add_custom_command(
                                 convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
                                 convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
                                 convert-func-to-llvm, reconcile-unrealized-casts)" |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/forward_auto_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_auto_vectorization.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_auto_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_auto_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
@@ -129,10 +131,10 @@ add_custom_command(
       -expand-strided-metadata
       -finalize-memref-to-llvm
       -reconcile-unrealized-casts |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_auto_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_auto_vectorization.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_auto_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_auto_vectorization.o
   DEPENDS 
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt

--- a/benchmarks/DeepLearning/Layers/RMSNorm/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Layers/RMSNorm/CMakeLists.txt
@@ -7,6 +7,8 @@ add_custom_command(
   COMMENT "Generating forward.mlir, subgraph0.mlir"
 )
 
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 add_custom_command(
   OUTPUT forward_scalar.o
   COMMAND
@@ -25,15 +27,16 @@ add_custom_command(
                                 convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
                                 convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
                                 convert-func-to-llvm, reconcile-unrealized-casts)" |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O0
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/forward_scalar.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_scalar.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} forward_scalar.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_scalar.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
   COMMENT "Building forward_scalar.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT subgraph0_scalar.o
@@ -64,10 +67,10 @@ add_custom_command(
       -expand-strided-metadata
       -finalize-memref-to-llvm
       -reconcile-unrealized-casts |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O0
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_scalar.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_scalar.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} subgraph0_scalar.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_scalar.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
@@ -92,15 +95,16 @@ add_custom_command(
                                 convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
                                 convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
                                 convert-func-to-llvm, reconcile-unrealized-casts)" |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/forward_auto_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_auto_vectorization.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_auto_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_auto_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
   COMMENT "Building forward_auto_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT subgraph0_auto_vectorization.o
@@ -129,15 +133,16 @@ add_custom_command(
       -expand-strided-metadata
       -finalize-memref-to-llvm
       -reconcile-unrealized-casts |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_auto_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_auto_vectorization.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_auto_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_auto_vectorization.o
   DEPENDS 
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
   COMMENT "Building subgraph0_auto_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_library(RMSNORM_SCALAR STATIC subgraph0_scalar.o forward_scalar.o)
 set_target_properties(RMSNORM_SCALAR PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/Layers/SelfAttention/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Layers/SelfAttention/CMakeLists.txt
@@ -7,6 +7,8 @@ add_custom_command(
   COMMENT "Generating forward.mlir, subgraph0.mlir"
 )
 
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 add_custom_command(
   OUTPUT forward_scalar.o
   COMMAND
@@ -25,15 +27,16 @@ add_custom_command(
                                 convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
                                 convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
                                 convert-func-to-llvm, reconcile-unrealized-casts)" |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O0
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/forward_scalar.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_scalar.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} forward_scalar.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_scalar.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
   COMMENT "Building forward_scalar.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT subgraph0_scalar.o
@@ -64,15 +67,16 @@ add_custom_command(
       -expand-strided-metadata
       -finalize-memref-to-llvm
       -reconcile-unrealized-casts |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O0
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_scalar.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_scalar.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} subgraph0_scalar.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_scalar.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
   COMMENT "Building subgraph0_scalar.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT forward_auto_vectorization.o
@@ -92,15 +96,16 @@ add_custom_command(
                                 convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
                                 convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
                                 convert-func-to-llvm, reconcile-unrealized-casts)" |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/forward_auto_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_auto_vectorization.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_auto_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_auto_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
   COMMENT "Building forward_auto_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT subgraph0_auto_vectorization.o
@@ -129,15 +134,16 @@ add_custom_command(
       -expand-strided-metadata
       -finalize-memref-to-llvm
       -reconcile-unrealized-casts |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_auto_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_auto_vectorization.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_auto_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_auto_vectorization.o
   DEPENDS 
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
   COMMENT "Building subgraph0_auto_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_library(SELFATTENTION_SCALAR STATIC subgraph0_scalar.o forward_scalar.o)
 set_target_properties(SELFATTENTION_SCALAR PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/Layers/SelfAttention/buddy_selfattention_import.py
+++ b/benchmarks/DeepLearning/Layers/SelfAttention/buddy_selfattention_import.py
@@ -1,5 +1,7 @@
 import os
 import torch
+import torch.nn.functional as F
+
 from torch._inductor.decomposition import decompositions as inductor_decomp
 
 from buddy.compiler.frontend import DynamoCompiler
@@ -7,16 +9,45 @@ from buddy.compiler.graph import GraphDriver
 from buddy.compiler.graph.transform import simply_fuse
 from buddy.compiler.ops import tosa
 
+
 class SelfAttentionLayer(torch.nn.Module):
     def __init__(self, embed_dim, num_heads):
         super(SelfAttentionLayer, self).__init__()
-        self.attention = torch.nn.MultiheadAttention(embed_dim, num_heads, batch_first=True)
-    
+
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+
+        self.q_proj = torch.nn.Linear(embed_dim, embed_dim)
+        self.k_proj = torch.nn.Linear(embed_dim, embed_dim)
+        self.v_proj = torch.nn.Linear(embed_dim, embed_dim)
+
+        self.out_proj = torch.nn.Linear(embed_dim, embed_dim)
+
     def forward(self, x):
-        # MultiheadAttention expects the input in the shape (batch_size, seq_len, embed_dim)
-        # Here we assume x is already in this shape.
-        attn_output, _ = self.attention(x, x, x)
-        return attn_output
+        batch_size, seq_len, embed_dim = x.size()
+
+        q = self.q_proj(x)
+        k = self.k_proj(x)
+        v = self.v_proj(x)
+
+        q = q.view(batch_size, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k.view(batch_size, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+        v = v.view(batch_size, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+
+        scores = torch.matmul(q, k.transpose(-2, -1)) / (self.head_dim**0.5)
+        attn_weights = F.softmax(scores, dim=-1)
+        attn_output = torch.matmul(attn_weights, v)
+
+        attn_output = (
+            attn_output.transpose(1, 2)
+            .contiguous()
+            .view(batch_size, seq_len, embed_dim)
+        )
+
+        output = self.out_proj(attn_output)
+        return output
+
 
 # Example usage
 embed_dim = 256

--- a/benchmarks/DeepLearning/Models/Bert/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Models/Bert/CMakeLists.txt
@@ -7,6 +7,8 @@ add_custom_command(
   COMMENT "Generating forward.mlir, subgraph0.mlir"
 )
 
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 add_custom_command(
   OUTPUT forward_auto_vectorization.o
   COMMAND
@@ -14,25 +16,26 @@ add_custom_command(
     sed -e {s/@forward/@forward_auto_vectorization/}
         -e {s/@subgraph0/@subgraph0_auto_vectorization/} |
     ${LLVM_MLIR_BINARY_DIR}/mlir-opt 
-    -pass-pipeline
-    "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith), \
-              empty-tensor-to-alloc-tensor, convert-elementwise-to-linalg, arith-bufferize, \
-              func.func(linalg-bufferize, tensor-bufferize), func-bufferize)" |
+      -pass-pipeline
+      "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith), \
+                empty-tensor-to-alloc-tensor, convert-elementwise-to-linalg, arith-bufferize, \
+                func.func(linalg-bufferize, tensor-bufferize), func-bufferize)" |
     ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-    -pass-pipeline
-    "builtin.module(func.func(buffer-deallocation-simplification, convert-linalg-to-loops), \
-              eliminate-empty-tensors, func.func(llvm-request-c-wrappers), \
-              convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
-              convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
-              convert-func-to-llvm, reconcile-unrealized-casts)" |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/forward_auto_vectorization.o
+      -pass-pipeline
+      "builtin.module(func.func(buffer-deallocation-simplification, convert-linalg-to-loops), \
+                eliminate-empty-tensors, func.func(llvm-request-c-wrappers), \
+                convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
+                convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
+                convert-func-to-llvm, reconcile-unrealized-casts)" |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_auto_vectorization.ll
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_auto_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_auto_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir
   COMMENT "Building forward_auto_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT subgraph0_auto_vectorization.o
@@ -60,15 +63,16 @@ add_custom_command(
       -expand-strided-metadata
       -finalize-memref-to-llvm
       -reconcile-unrealized-casts |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_auto_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_auto_vectorization.ll
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_auto_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_auto_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
   COMMENT "Building subgraph0_auto_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
   add_custom_command(
     OUTPUT forward_buddy_vectorization.o
@@ -76,22 +80,22 @@ add_custom_command(
       cat ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir |
       sed -e {s/@forward/@forward_buddy_vectorization/}
           -e {s/@subgraph0/@subgraph0_buddy_vectorization/} |
-          ${LLVM_MLIR_BINARY_DIR}/mlir-opt 
-          -pass-pipeline
-          "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith), \
-                    empty-tensor-to-alloc-tensor, convert-elementwise-to-linalg, arith-bufferize, \
-                    func.func(linalg-bufferize, tensor-bufferize), func-bufferize)" |
-          ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-          -pass-pipeline
-          "builtin.module(func.func(buffer-deallocation-simplification, convert-linalg-to-loops), \
-                    eliminate-empty-tensors, func.func(llvm-request-c-wrappers), \
-                    convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
-                    convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
-                    convert-func-to-llvm, reconcile-unrealized-casts)" |
-      ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-      ${LLVM_MLIR_BINARY_DIR}/llc -O3
-        -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-        -o ${CMAKE_CURRENT_BINARY_DIR}/forward_buddy_vectorization.o
+      ${LLVM_MLIR_BINARY_DIR}/mlir-opt 
+        -pass-pipeline
+        "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith), \
+                  empty-tensor-to-alloc-tensor, convert-elementwise-to-linalg, arith-bufferize, \
+                  func.func(linalg-bufferize, tensor-bufferize), func-bufferize)" |
+      ${LLVM_MLIR_BINARY_DIR}/mlir-opt
+        -pass-pipeline
+        "builtin.module(func.func(buffer-deallocation-simplification, convert-linalg-to-loops), \
+                  eliminate-empty-tensors, func.func(llvm-request-c-wrappers), \
+                  convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
+                  convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
+                  convert-func-to-llvm, reconcile-unrealized-casts)" |
+      ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_buddy_vectorization.ll
+    COMMAND
+      ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_buddy_vectorization.ll
+        -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_buddy_vectorization.o
     DEPENDS
       ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir
     COMMENT "Building forward_buddy_vectorization.o"
@@ -126,10 +130,10 @@ add_custom_command(
       -expand-strided-metadata
       -finalize-memref-to-llvm
       -reconcile-unrealized-casts |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_buddy_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_buddy_vectorization.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_buddy_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_buddy_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt

--- a/benchmarks/DeepLearning/Models/LeNet/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Models/LeNet/CMakeLists.txt
@@ -7,6 +7,8 @@ add_custom_command(
   COMMENT "Generating forward.mlir, subgraph0.mlir"
 )
 
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 add_custom_command(
   OUTPUT forward_auto_vectorization.o
   COMMAND 
@@ -25,15 +27,16 @@ add_custom_command(
                                 convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
                                 convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
                                 convert-func-to-llvm, reconcile-unrealized-casts)" |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/forward_auto_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_auto_vectorization.ll
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_auto_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_auto_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
   COMMENT "Building forward_auto_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT subgraph0_auto_vectorization.o
@@ -62,15 +65,16 @@ add_custom_command(
       -expand-strided-metadata
       -finalize-memref-to-llvm
       -reconcile-unrealized-casts |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_auto_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_auto_vectorization.ll
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_auto_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_auto_vectorization.o
   DEPENDS 
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
   COMMENT "Building subgraph0_auto_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT forward_buddy_vectorization.o
@@ -90,15 +94,15 @@ add_custom_command(
                                 convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
                                 convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
                                 convert-func-to-llvm, reconcile-unrealized-casts)" |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/forward_buddy_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_buddy_vectorization.ll
+    COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_buddy_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_buddy_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
   COMMENT "Building forward_buddy_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT subgraph0_buddy_vectorization.o
@@ -130,15 +134,15 @@ add_custom_command(
       -expand-strided-metadata
       -finalize-memref-to-llvm
       -reconcile-unrealized-casts |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_buddy_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_buddy_vectorization.ll
+    COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_buddy_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_buddy_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
   COMMENT "Building subgraph0_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_library(LENET_AUTO_VECTORIZATION STATIC subgraph0_auto_vectorization.o forward_auto_vectorization.o)
 set_target_properties(LENET_AUTO_VECTORIZATION PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/Models/LeNet/buddy_lenet_import.py
+++ b/benchmarks/DeepLearning/Models/LeNet/buddy_lenet_import.py
@@ -45,7 +45,6 @@ def main():
     # Initialize Dynamo Compiler with specific configurations as an importer.
     dynamo_compiler = DynamoCompiler(
         primary_registry=tosa.ops_registry,
-        aot_autograd_decomposition=inductor_decomp,
     )
 
     data = torch.randn([1, 1, 28, 28])

--- a/benchmarks/DeepLearning/Models/MobileNet-V3/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Models/MobileNet-V3/CMakeLists.txt
@@ -27,56 +27,64 @@ separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
 ################################################################################
 add_custom_command(
   OUTPUT forward_scalar.o
-  COMMAND cat ${BUDDY_BENCHMARK_DEEP_LEARNING_DIR}/Models/MobileNet-V3/forward.mlir |
+  COMMAND 
+    cat ${BUDDY_BENCHMARK_DEEP_LEARNING_DIR}/Models/MobileNet-V3/forward.mlir |
     sed -e {s/@forward/@forward_scalar/} -e {s/@subgraph0/@subgraph0_scalar/} |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-    -expand-strided-metadata
-    -finalize-memref-to-llvm
-    -llvm-request-c-wrappers
-    -convert-func-to-llvm
-    -reconcile-unrealized-casts |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_scalar.ll
-  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_scalar.ll
-    -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_scalar.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-opt
+      -expand-strided-metadata
+      -finalize-memref-to-llvm
+      -llvm-request-c-wrappers
+      -convert-func-to-llvm
+      -reconcile-unrealized-casts |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_scalar.ll
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_scalar.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_scalar.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir
   COMMENT "Building forward_scalar.o"
-  VERBATIM)
+  VERBATIM
+)
+
 add_custom_command(
   OUTPUT subgraph0_scalar.o
-  COMMAND cat ${BUDDY_BENCHMARK_DEEP_LEARNING_DIR}/Models/MobileNet-V3/subgraph0.mlir |
+  COMMAND 
+    cat ${BUDDY_BENCHMARK_DEEP_LEARNING_DIR}/Models/MobileNet-V3/subgraph0.mlir |
     sed -e {s/@subgraph0/@subgraph0_scalar/} |
-  ${BUDDY_MLIR_BINARY_DIR}/buddy-opt 
-  -pass-pipeline
-  "builtin.module(func.func(tosa-to-linalg-named, tosa-to-arith, tosa-to-linalg, tosa-to-tensor))" |
-  ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
-    -convert-elementwise-to-linalg
-    -linalg-named-op-conversion
-    -convert-math-to-llvm
-    -convert-math-to-libm
-    -one-shot-bufferize
-    -convert-linalg-to-affine-loops
-    -lower-affine
-    -func-bufferize
-    -tensor-bufferize
-    -arith-bufferize
-    -finalizing-bufferize
-    -convert-vector-to-scf
-    -expand-strided-metadata
-    -convert-vector-to-llvm
-    -finalize-memref-to-llvm
-    -convert-scf-to-cf
-    -llvm-request-c-wrappers
-    -convert-arith-to-llvm
-    -convert-func-to-llvm
-    -reconcile-unrealized-casts |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_scalar.ll
-  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_scalar.ll
-    -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_scalar.o
+    ${BUDDY_MLIR_BINARY_DIR}/buddy-opt 
+      -pass-pipeline
+      "builtin.module(func.func(tosa-to-linalg-named, tosa-to-arith, tosa-to-linalg, tosa-to-tensor))" |
+    ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
+      -convert-elementwise-to-linalg
+      -linalg-named-op-conversion
+      -convert-math-to-llvm
+      -convert-math-to-libm
+      -one-shot-bufferize
+      -convert-linalg-to-affine-loops
+      -lower-affine
+      -func-bufferize
+      -tensor-bufferize
+      -arith-bufferize
+      -finalizing-bufferize
+      -convert-vector-to-scf
+      -expand-strided-metadata
+      -convert-vector-to-llvm
+      -finalize-memref-to-llvm
+      -convert-scf-to-cf
+      -llvm-request-c-wrappers
+      -convert-arith-to-llvm
+      -convert-func-to-llvm
+      -reconcile-unrealized-casts |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_scalar.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_scalar.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_scalar.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
   COMMENT "Building subgraph0_scalar.o"
-  VERBATIM)
+  VERBATIM
+)
+
 add_library(mobilenetv3_scalar STATIC subgraph0_scalar.o forward_scalar.o)
 set_target_properties(mobilenetv3_scalar PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(dl-model-mobilenetv3-benchmark
@@ -91,60 +99,67 @@ target_link_libraries(dl-model-mobilenetv3-benchmark
 ################################################################################
 add_custom_command(
   OUTPUT forward_conv_opt.o
-  COMMAND cat ${BUDDY_BENCHMARK_DEEP_LEARNING_DIR}/Models/MobileNet-V3/forward.mlir |
+  COMMAND 
+    cat ${BUDDY_BENCHMARK_DEEP_LEARNING_DIR}/Models/MobileNet-V3/forward.mlir |
     sed -e {s/@forward/@forward_conv_opt/} 
         -e {s/@subgraph0/@subgraph0_conv_opt/} |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-    -expand-strided-metadata
-    -finalize-memref-to-llvm
-    -llvm-request-c-wrappers
-    -convert-func-to-llvm
-    -reconcile-unrealized-casts |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_conv_opt.ll
-  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_conv_opt.ll
-    -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_conv_opt.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-opt
+      -expand-strided-metadata
+      -finalize-memref-to-llvm
+      -llvm-request-c-wrappers
+      -convert-func-to-llvm
+      -reconcile-unrealized-casts |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_conv_opt.ll
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_conv_opt.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_conv_opt.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir
   COMMENT "Building forward_conv_opt.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT subgraph0_conv_opt.o
-  COMMAND cat ${BUDDY_BENCHMARK_DEEP_LEARNING_DIR}/Models/MobileNet-V3/subgraph0.mlir |
+  COMMAND 
+    cat ${BUDDY_BENCHMARK_DEEP_LEARNING_DIR}/Models/MobileNet-V3/subgraph0.mlir |
     sed -e {s/@subgraph0/@subgraph0_conv_opt/} |
-  ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
-    -pass-pipeline
-    "builtin.module(func.func(tosa-to-linalg-named, tosa-to-arith, tosa-to-linalg, tosa-to-tensor))" |
-  ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
-    -convert-elementwise-to-linalg
-    -linalg-named-op-conversion
-    -convert-math-to-llvm
-    -convert-math-to-libm
-    -one-shot-bufferize
-    -conv-nhwc-fhwc-optimize # conv-nhwc-fhwc optimization
-    -depthwise-conv-nhwc-hwc-optimize # depthwise-conv-nhwc-hwc optimization
-    -convert-linalg-to-affine-loops
-    -lower-affine
-    -func-bufferize
-    -tensor-bufferize
-    -arith-bufferize
-    -finalizing-bufferize
-    -convert-vector-to-scf
-    -expand-strided-metadata
-    -convert-vector-to-llvm
-    -finalize-memref-to-llvm
-    -convert-scf-to-cf
-    -llvm-request-c-wrappers
-    -convert-arith-to-llvm
-    -convert-func-to-llvm
-    -reconcile-unrealized-casts |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_conv_opt.ll
-  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_conv_opt.ll
-    -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_conv_opt.o
+    ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
+      -pass-pipeline
+      "builtin.module(func.func(tosa-to-linalg-named, tosa-to-arith, tosa-to-linalg, tosa-to-tensor))" |
+    ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
+      -convert-elementwise-to-linalg
+      -linalg-named-op-conversion
+      -convert-math-to-llvm
+      -convert-math-to-libm
+      -one-shot-bufferize
+      -conv-nhwc-fhwc-optimize # conv-nhwc-fhwc optimization
+      -depthwise-conv-nhwc-hwc-optimize # depthwise-conv-nhwc-hwc optimization
+      -convert-linalg-to-affine-loops
+      -lower-affine
+      -func-bufferize
+      -tensor-bufferize
+      -arith-bufferize
+      -finalizing-bufferize
+      -convert-vector-to-scf
+      -expand-strided-metadata
+      -convert-vector-to-llvm
+      -finalize-memref-to-llvm
+      -convert-scf-to-cf
+      -llvm-request-c-wrappers
+      -convert-arith-to-llvm
+      -convert-func-to-llvm
+      -reconcile-unrealized-casts |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_conv_opt.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_conv_opt.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_conv_opt.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
   COMMENT "Building subgraph0_conv_opt.o"
-  VERBATIM)
+  VERBATIM
+)
+
 add_library(mobilenetv3_conv_opt STATIC subgraph0_conv_opt.o forward_conv_opt.o)
 set_target_properties(mobilenetv3_conv_opt PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(dl-model-mobilenetv3-benchmark

--- a/benchmarks/DeepLearning/Models/MobileNet-V3/GoogleBenchmarkMain.cpp
+++ b/benchmarks/DeepLearning/Models/MobileNet-V3/GoogleBenchmarkMain.cpp
@@ -56,14 +56,11 @@ namespace {
 // Declare the mobilenet C interface.
 extern "C" {
 void _mlir_ciface_forward_scalar(MemRef<float, 2> *output,
-                                             MemRef<float, 1> *arg0,
-                                             MemRef<long long, 1> *arg1,
-                                             Img<float, 4> *input);
+                                 MemRef<float, 1> *arg0, Img<float, 4> *input);
 
 void _mlir_ciface_forward_conv_opt(MemRef<float, 2> *output,
-                                        MemRef<float, 1> *arg0,
-                                        MemRef<long long, 1> *arg1,
-                                        Img<float, 4> *input);
+                                   MemRef<float, 1> *arg0,
+                                   Img<float, 4> *input);
 }
 
 template <typename Func>
@@ -82,10 +79,9 @@ void BM_MobileNet_V3(benchmark::State &state, Func func) {
 
   // Set random model parameters.
   MemRef<float, 1> paramsContainerf32({ParamsSize}, 2.0);
-  MemRef<long long, 1> ParamsContainerInt64({34}, 1.0);
 
   for (auto _ : state) {
-    func(&output, &paramsContainerf32, &ParamsContainerInt64, &input);
+    func(&output, &paramsContainerf32, &input);
   }
 }
 
@@ -130,13 +126,11 @@ void verification() {
 
   // Load model parameters from the specified file.
   MemRef<float, 1> paramsContainerf32({ParamsSize}, 3.0);
-  MemRef<long long, 1> ParamsContainerInt64({34}, 2.0);
 
   // Call the forward function of the model.
-  _mlir_ciface_forward_scalar(&outputScalar, &paramsContainerf32,
-                                          &ParamsContainerInt64, &input);
+  _mlir_ciface_forward_scalar(&outputScalar, &paramsContainerf32, &input);
   _mlir_ciface_forward_conv_opt(&outputVectorization, &paramsContainerf32,
-                                     &ParamsContainerInt64, &input);
+                                &input);
 
   auto resultScalar = outputScalar.getData();
   auto resultVectorization = outputVectorization.getData();

--- a/benchmarks/DeepLearning/Models/MobileNet-V3/buddy_mobilenetv3_import.py
+++ b/benchmarks/DeepLearning/Models/MobileNet-V3/buddy_mobilenetv3_import.py
@@ -37,6 +37,11 @@ model = models.mobilenet_v3_small(
 )
 model = model.eval()
 
+for layer in model.modules():
+    if isinstance(layer, torch.nn.BatchNorm2d):
+        if hasattr(layer, "num_batches_tracked"):
+            del layer.num_batches_tracked
+
 # Initialize Dynamo Compiler with specific configurations as an importer.
 dynamo_compiler = DynamoCompiler(
     primary_registry=tosa.ops_registry,

--- a/benchmarks/DeepLearning/Models/Resnet18/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Models/Resnet18/CMakeLists.txt
@@ -7,6 +7,8 @@ add_custom_command(
   COMMENT "Generating forward.mlir, subgraph0.mlir..."
 )
 
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 add_custom_command(
   OUTPUT forward_auto_vectorization.o
   COMMAND
@@ -14,25 +16,26 @@ add_custom_command(
     sed -e {s/@forward/@forward_auto_vectorization/}
         -e {s/@subgraph0/@subgraph0_auto_vectorization/} |
     ${LLVM_MLIR_BINARY_DIR}/mlir-opt 
-    -pass-pipeline
-    "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith), \
-              empty-tensor-to-alloc-tensor, convert-elementwise-to-linalg, arith-bufferize, \
-              func.func(linalg-bufferize, tensor-bufferize), func-bufferize)" |
+      -pass-pipeline
+      "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith), \
+                empty-tensor-to-alloc-tensor, convert-elementwise-to-linalg, arith-bufferize, \
+                func.func(linalg-bufferize, tensor-bufferize), func-bufferize)" |
     ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-    -pass-pipeline
-    "builtin.module(func.func(buffer-deallocation-simplification, convert-linalg-to-loops), \
-              eliminate-empty-tensors, func.func(llvm-request-c-wrappers), \
-              convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
-              convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
-              convert-func-to-llvm, reconcile-unrealized-casts)" |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/forward_auto_vectorization.o
+      -pass-pipeline
+      "builtin.module(func.func(buffer-deallocation-simplification, convert-linalg-to-loops), \
+                eliminate-empty-tensors, func.func(llvm-request-c-wrappers), \
+                convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
+                convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
+                convert-func-to-llvm, reconcile-unrealized-casts)" |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_auto_vectorization.ll
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_auto_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_auto_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir
   COMMENT "Building forward_auto_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT subgraph0_auto_vectorization.o
@@ -61,15 +64,16 @@ add_custom_command(
     -expand-strided-metadata
     -finalize-memref-to-llvm
     -reconcile-unrealized-casts |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_auto_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_auto_vectorization.ll
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_auto_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_auto_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
   COMMENT "Building subgraph0_auto_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT forward_buddy_vectorization.o
@@ -77,26 +81,27 @@ add_custom_command(
     cat ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir |
     sed -e {s/@forward/@forward_buddy_vectorization/}
         -e {s/@subgraph0/@subgraph0_buddy_vectorization/} |
-        ${LLVM_MLIR_BINARY_DIR}/mlir-opt 
-        -pass-pipeline
-        "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith), \
-                  empty-tensor-to-alloc-tensor, convert-elementwise-to-linalg, arith-bufferize, \
-                  func.func(linalg-bufferize, tensor-bufferize), func-bufferize)" |
-        ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-        -pass-pipeline
-        "builtin.module(func.func(buffer-deallocation-simplification, convert-linalg-to-loops), \
-                  eliminate-empty-tensors, func.func(llvm-request-c-wrappers), \
-                  convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
-                  convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
-                  convert-func-to-llvm, reconcile-unrealized-casts)" |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/forward_buddy_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-opt 
+      -pass-pipeline
+      "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith), \
+                empty-tensor-to-alloc-tensor, convert-elementwise-to-linalg, arith-bufferize, \
+                func.func(linalg-bufferize, tensor-bufferize), func-bufferize)" |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-opt
+      -pass-pipeline
+      "builtin.module(func.func(buffer-deallocation-simplification, convert-linalg-to-loops), \
+                eliminate-empty-tensors, func.func(llvm-request-c-wrappers), \
+                convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
+                convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
+                convert-func-to-llvm, reconcile-unrealized-casts)" |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_buddy_vectorization.ll
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_buddy_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_buddy_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir
   COMMENT "Building forward_buddy_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT subgraph0_buddy_vectorization.o
@@ -128,15 +133,16 @@ add_custom_command(
       -expand-strided-metadata
       -finalize-memref-to-llvm
       -reconcile-unrealized-casts |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_buddy_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_buddy_vectorization.ll
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_buddy_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_buddy_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
   COMMENT "Building subgraph0_buddy_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_library(RESNET18_AUTO_VECTORIZATION STATIC subgraph0_auto_vectorization.o forward_auto_vectorization.o)
 set_target_properties(RESNET18_AUTO_VECTORIZATION PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/Models/Resnet18/GoogleBenchmarkMain.cpp
+++ b/benchmarks/DeepLearning/Models/Resnet18/GoogleBenchmarkMain.cpp
@@ -13,7 +13,7 @@ constexpr size_t OutputSize = 1000;
 constexpr size_t InputChannels = 3;
 constexpr size_t InputHeight = 224;
 constexpr size_t InputWidth = 224;
-constexpr size_t ExtraInputSize = 20;  
+constexpr size_t ExtraInputSize = 20;
 const std::string PASS = "\033[32mPASS\033[0m";
 const std::string FAIL = "\033[31mFAIL\033[0m";
 
@@ -32,16 +32,12 @@ namespace {
 
 // Declare the ResNet18 C interface.
 extern "C" {
-void _mlir_ciface_forward_auto_vectorization(
-                                             MemRef<float, 2> *output,
+void _mlir_ciface_forward_auto_vectorization(MemRef<float, 2> *output,
                                              MemRef<float, 1> *params,
-                                             MemRef<long long, 1> *extra_input,
                                              MemRef<float, 4> *input);
 
-void _mlir_ciface_forward_buddy_vectorization(
-                                              MemRef<float, 2> *output,
+void _mlir_ciface_forward_buddy_vectorization(MemRef<float, 2> *output,
                                               MemRef<float, 1> *params,
-                                              MemRef<long long, 1> *extra_input,
                                               MemRef<float, 4> *input);
 }
 
@@ -49,12 +45,12 @@ template <typename Func>
 void DL_MODEL_Resnet18(benchmark::State &state, Func func) {
   // Create containers for input, output, parameters, and extra_input.
   MemRef<float, 1> paramsContainerf32({ParamsSize}, 5);
-  MemRef<float, 4> inputContainer({1, InputChannels, InputHeight, InputWidth}, 6);
+  MemRef<float, 4> inputContainer({1, InputChannels, InputHeight, InputWidth},
+                                  6);
   MemRef<float, 2> outputContainer({1, OutputSize}, 7);
-  MemRef<long long, 1> extraInputContainer({ExtraInputSize}, 8);  
 
   for (auto _ : state) {
-    func(&outputContainer, &paramsContainerf32, &extraInputContainer, &inputContainer);  
+    func(&outputContainer, &paramsContainerf32, &inputContainer);
   }
 }
 
@@ -82,27 +78,22 @@ void verification() {
   std::uniform_real_distribution<float> distribution(0.0, 1.0);
 
   // Create containers for input, output, parameters, and extra input.
-  MemRef<float, 4> inputContainer({1, InputChannels, InputHeight, InputWidth}, 6);
+  MemRef<float, 4> inputContainer({1, InputChannels, InputHeight, InputWidth},
+                                  6);
   MemRef<float, 2> resultAutoVectorizationContainer({1, OutputSize}, 7);
   MemRef<float, 2> resultBuddyVectorizationContainer({1, OutputSize}, 7);
   MemRef<float, 1> paramsContainerf32({ParamsSize}, 5);
-  MemRef<long long, 1> extraInputContainer({ExtraInputSize}, 8);  // 使用超参数控制维度
 
   // Populate input with random data
   for (int i = 0; i < InputChannels * InputHeight * InputWidth; ++i) {
     inputContainer.getData()[i] = distribution(generator);
   }
 
-  // Populate the extra input with some data
-  for (int i = 0; i < ExtraInputSize; ++i) {
-    extraInputContainer.getData()[i] = rd();
-  }
-
   // Call the forward function of the model.
   _mlir_ciface_forward_auto_vectorization(&resultAutoVectorizationContainer,
-                                          &paramsContainerf32, &extraInputContainer, &inputContainer);
-  _mlir_ciface_forward_buddy_vectorization(&resultBuddyVectorizationContainer,
-                                           &paramsContainerf32, &extraInputContainer, &inputContainer);
+                                          &paramsContainerf32, &inputContainer);
+  _mlir_ciface_forward_buddy_vectorization(
+      &resultBuddyVectorizationContainer, &paramsContainerf32, &inputContainer);
 
   // Compare results.
   auto resultAutoVectorization = resultAutoVectorizationContainer.getData();

--- a/benchmarks/DeepLearning/Models/TinyLlama/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Models/TinyLlama/CMakeLists.txt
@@ -27,60 +27,66 @@ separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
 ################################################################################
 add_custom_command(
   OUTPUT forward_scalar.o
-  COMMAND cat ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir |
+  COMMAND 
+    cat ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir |
     sed -e {s/@forward/@forward_scalar/} |
     sed -e {s/@subgraph0/@subgraph0_scalar/} |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-    -expand-strided-metadata
-    -finalize-memref-to-llvm
-    -llvm-request-c-wrappers
-    -convert-func-to-llvm
-    -reconcile-unrealized-casts |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_scalar.ll
-  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_scalar.ll
-    -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_scalar.o
-  DEPENDS
+    ${LLVM_MLIR_BINARY_DIR}/mlir-opt
+      -expand-strided-metadata
+      -finalize-memref-to-llvm
+      -llvm-request-c-wrappers
+      -convert-func-to-llvm
+      -reconcile-unrealized-casts |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_scalar.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_scalar.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_scalar.o
+  DEPENDS 
     ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir
   COMMENT "Building forward_scalar.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT subgraph0_scalar.o
-  COMMAND cat ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir |
+  COMMAND 
+    cat ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir |
     sed -e {s/@subgraph0/@subgraph0_scalar/} |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-    -pass-pipeline 
-    "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))" |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-    -eliminate-empty-tensors
-    -empty-tensor-to-alloc-tensor
-    -convert-elementwise-to-linalg
-    -one-shot-bufferize
-    -convert-linalg-to-affine-loops
-    -lower-affine
-    -func-bufferize
-    -tensor-bufferize
-    -arith-bufferize
-    -buffer-deallocation
-    -finalizing-bufferize
-    -convert-vector-to-scf
-    -expand-strided-metadata
-    -convert-vector-to-llvm
-    -finalize-memref-to-llvm
-    -convert-scf-to-cf
-    -llvm-request-c-wrappers
-    -convert-arith-to-llvm
-    -convert-math-to-llvm
-    -convert-math-to-libm 
-    -convert-func-to-llvm
-    -reconcile-unrealized-casts |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_scalar.ll
-  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_scalar.ll
-    -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_scalar.o
-  DEPENDS
+    ${LLVM_MLIR_BINARY_DIR}/mlir-opt
+      -pass-pipeline 
+      "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))" |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-opt
+      -eliminate-empty-tensors
+      -empty-tensor-to-alloc-tensor
+      -convert-elementwise-to-linalg
+      -one-shot-bufferize
+      -convert-linalg-to-affine-loops
+      -lower-affine
+      -func-bufferize
+      -tensor-bufferize
+      -arith-bufferize
+      -buffer-deallocation
+      -finalizing-bufferize
+      -convert-vector-to-scf
+      -expand-strided-metadata
+      -convert-vector-to-llvm
+      -finalize-memref-to-llvm
+      -convert-scf-to-cf
+      -llvm-request-c-wrappers
+      -convert-arith-to-llvm
+      -convert-math-to-llvm
+      -convert-math-to-libm 
+      -convert-func-to-llvm
+      -reconcile-unrealized-casts |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_scalar.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_scalar.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_scalar.o
+  DEPENDS 
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
   COMMENT "Building subgraph0_scalar.o"
-  VERBATIM)
+  VERBATIM
+)
 add_library(tinyllama_scalar STATIC subgraph0_scalar.o forward_scalar.o)
 set_target_properties(tinyllama_scalar PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(dl-model-tinyllama-benchmark
@@ -95,62 +101,69 @@ target_link_libraries(dl-model-tinyllama-benchmark
 ################################################################################
 add_custom_command(
   OUTPUT forward_matmul_opt.o
-  COMMAND cat ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir |
+  COMMAND 
+    cat ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir |
     sed -e {s/@forward/@forward_matmul_opt/} |
     sed -e {s/@subgraph0/@subgraph0_matmul_opt/} |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-    -expand-strided-metadata
-    -finalize-memref-to-llvm
-    -llvm-request-c-wrappers
-    -convert-func-to-llvm
-    -reconcile-unrealized-casts |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_matmul_opt.ll
-  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_matmul_opt.ll
-    -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_matmul_opt.o
-  DEPENDS
+    ${LLVM_MLIR_BINARY_DIR}/mlir-opt
+      -expand-strided-metadata
+      -finalize-memref-to-llvm
+      -llvm-request-c-wrappers
+      -convert-func-to-llvm
+      -reconcile-unrealized-casts |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_matmul_opt.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_matmul_opt.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_matmul_opt.o
+  DEPENDS 
     ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir
   COMMENT "Building forward_matmul_opt.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT subgraph0_matmul_opt.o
-  COMMAND cat ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir |
+  COMMAND 
+    cat ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir |
     sed -e {s/@subgraph0/@subgraph0_matmul_opt/} |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-    -pass-pipeline 
-    "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))" |
-  ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
-    -eliminate-empty-tensors
-    -empty-tensor-to-alloc-tensor
-    -convert-elementwise-to-linalg
-    -one-shot-bufferize
-    -matmul-parallel-vectorization-optimize # new added
-    -batchmatmul-optimize # new added
-    -convert-linalg-to-affine-loops
-    -lower-affine
-    -func-bufferize
-    -tensor-bufferize
-    -arith-bufferize
-    -buffer-deallocation
-    -finalizing-bufferize
-    -convert-vector-to-scf
-    -expand-strided-metadata
-    -convert-vector-to-llvm
-    -finalize-memref-to-llvm
-    -convert-scf-to-cf
-    -llvm-request-c-wrappers
-    -convert-arith-to-llvm
-    -convert-math-to-llvm
-    -convert-math-to-libm 
-    -convert-func-to-llvm
-    -reconcile-unrealized-casts |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_matmul_opt.ll
-  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_matmul_opt.ll
-    -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_matmul_opt.o
-  DEPENDS
+    ${LLVM_MLIR_BINARY_DIR}/mlir-opt
+      -pass-pipeline 
+      "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))" |
+    ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
+      -eliminate-empty-tensors
+      -empty-tensor-to-alloc-tensor
+      -convert-elementwise-to-linalg
+      -one-shot-bufferize
+      -matmul-parallel-vectorization-optimize # new added
+      -batchmatmul-optimize # new added
+      -convert-linalg-to-affine-loops
+      -lower-affine
+      -func-bufferize
+      -tensor-bufferize
+      -arith-bufferize
+      -buffer-deallocation
+      -finalizing-bufferize
+      -convert-vector-to-scf
+      -expand-strided-metadata
+      -convert-vector-to-llvm
+      -finalize-memref-to-llvm
+      -convert-scf-to-cf
+      -llvm-request-c-wrappers
+      -convert-arith-to-llvm
+      -convert-math-to-llvm
+      -convert-math-to-libm 
+      -convert-func-to-llvm
+      -reconcile-unrealized-casts |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_matmul_opt.ll
+  COMMAND 
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_matmul_opt.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_matmul_opt.o
+  DEPENDS 
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
   COMMENT "Building subgraph0_matmul_opt.o"
-  VERBATIM)
+  VERBATIM
+)
+
 add_library(tinyllama_matmul_opt STATIC subgraph0_matmul_opt.o forward_matmul_opt.o)
 set_target_properties(tinyllama_matmul_opt PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(dl-model-tinyllama-benchmark

--- a/benchmarks/DeepLearning/Models/TinyLlama/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Models/TinyLlama/CMakeLists.txt
@@ -54,6 +54,7 @@ add_custom_command(
   ${LLVM_MLIR_BINARY_DIR}/mlir-opt
     -eliminate-empty-tensors
     -empty-tensor-to-alloc-tensor
+    -convert-elementwise-to-linalg
     -one-shot-bufferize
     -convert-linalg-to-affine-loops
     -lower-affine
@@ -121,6 +122,7 @@ add_custom_command(
   ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
     -eliminate-empty-tensors
     -empty-tensor-to-alloc-tensor
+    -convert-elementwise-to-linalg
     -one-shot-bufferize
     -matmul-parallel-vectorization-optimize # new added
     -batchmatmul-optimize # new added

--- a/benchmarks/DeepLearning/Models/Whisper/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Models/Whisper/CMakeLists.txt
@@ -7,6 +7,8 @@ add_custom_command(
   COMMENT "Generating forward.mlir, subgraph0.mlir..."
 )
 
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 add_custom_command(
   OUTPUT forward_auto_vectorization.o
   COMMAND
@@ -14,25 +16,26 @@ add_custom_command(
     sed -e {s/@forward/@forward_auto_vectorization/}
         -e {s/@subgraph0/@subgraph0_auto_vectorization/} |
     ${LLVM_MLIR_BINARY_DIR}/mlir-opt 
-        -pass-pipeline
-        "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith), \
-                  empty-tensor-to-alloc-tensor, convert-elementwise-to-linalg, arith-bufferize, \
-                  func.func(linalg-bufferize, tensor-bufferize), func-bufferize)" |
+      -pass-pipeline
+      "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith), \
+                empty-tensor-to-alloc-tensor, convert-elementwise-to-linalg, arith-bufferize, \
+                func.func(linalg-bufferize, tensor-bufferize), func-bufferize)" |
     ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-        -pass-pipeline
-        "builtin.module(func.func(buffer-deallocation-simplification, convert-linalg-to-loops), \
-                  eliminate-empty-tensors, func.func(llvm-request-c-wrappers), \
-                  convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
-                  convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
-                  convert-func-to-llvm, reconcile-unrealized-casts)" |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/forward_auto_vectorization.o
+      -pass-pipeline
+      "builtin.module(func.func(buffer-deallocation-simplification, convert-linalg-to-loops), \
+                eliminate-empty-tensors, func.func(llvm-request-c-wrappers), \
+                convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
+                convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
+                convert-func-to-llvm, reconcile-unrealized-casts)" |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_auto_vectorization.ll
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_auto_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_auto_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir
   COMMENT "Building forward_auto_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT subgraph0_auto_vectorization.o
@@ -40,46 +43,47 @@ add_custom_command(
     cat ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir |
     sed -e {s/@subgraph0/@subgraph0_auto_vectorization/} |
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
-    -pass-pipeline "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith))" |
+      -pass-pipeline "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith))" |
     ${LLVM_MLIR_BINARY_DIR}/mlir-opt 
       -test-linalg-transform-patterns=${PATTERN_ARG} |
-      ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
-        -arith-expand
-        -eliminate-empty-tensors
-        -convert-elementwise-to-linalg
-        -empty-tensor-to-alloc-tensor
-        -one-shot-bufferize
-        -convert-linalg-to-affine-loops
-        -affine-loop-fusion
-        -affine-parallelize
-        -lower-affine
-        -func-bufferize-dynamic-offset
-        -tensor-bufferize
-        -convert-linalg-to-loops
-        -finalizing-bufferize
-        -convert-vector-to-scf
-        -expand-strided-metadata
-        -cse
-        -convert-vector-to-llvm
-        -memref-expand
-        -convert-arith-to-llvm
-        -finalize-memref-to-llvm
-        -convert-scf-to-cf
-        -llvm-request-c-wrappers
-        -convert-arith-to-llvm
-        -convert-math-to-llvm
-        -convert-math-to-libm 
-        -convert-func-to-llvm
-        -reconcile-unrealized-casts |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_auto_vectorization.o
+    ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
+      -arith-expand
+      -eliminate-empty-tensors
+      -convert-elementwise-to-linalg
+      -empty-tensor-to-alloc-tensor
+      -one-shot-bufferize
+      -convert-linalg-to-affine-loops
+      -affine-loop-fusion
+      -affine-parallelize
+      -lower-affine
+      -func-bufferize-dynamic-offset
+      -tensor-bufferize
+      -convert-linalg-to-loops
+      -finalizing-bufferize
+      -convert-vector-to-scf
+      -expand-strided-metadata
+      -cse
+      -convert-vector-to-llvm
+      -memref-expand
+      -convert-arith-to-llvm
+      -finalize-memref-to-llvm
+      -convert-scf-to-cf
+      -llvm-request-c-wrappers
+      -convert-arith-to-llvm
+      -convert-math-to-llvm
+      -convert-math-to-libm 
+      -convert-func-to-llvm
+      -reconcile-unrealized-casts |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_auto_vectorization.ll
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_auto_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_auto_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
   COMMENT "Building subgraph0_auto_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT forward_buddy_vectorization.o
@@ -88,25 +92,26 @@ add_custom_command(
     sed -e {s/@forward/@forward_buddy_vectorization/}
         -e {s/@subgraph0/@subgraph0_buddy_vectorization/} |
     ${LLVM_MLIR_BINARY_DIR}/mlir-opt 
-        -pass-pipeline
-        "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith), \
-                  empty-tensor-to-alloc-tensor, convert-elementwise-to-linalg, arith-bufferize, \
-                  func.func(linalg-bufferize, tensor-bufferize), func-bufferize)" |
+      -pass-pipeline
+      "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith), \
+                empty-tensor-to-alloc-tensor, convert-elementwise-to-linalg, arith-bufferize, \
+                func.func(linalg-bufferize, tensor-bufferize), func-bufferize)" |
     ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-        -pass-pipeline
-        "builtin.module(func.func(buffer-deallocation-simplification, convert-linalg-to-loops), \
-                  eliminate-empty-tensors, func.func(llvm-request-c-wrappers), \
-                  convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
-                  convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
-                  convert-func-to-llvm, reconcile-unrealized-casts)" |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/forward_buddy_vectorization.o
+      -pass-pipeline
+      "builtin.module(func.func(buffer-deallocation-simplification, convert-linalg-to-loops), \
+                eliminate-empty-tensors, func.func(llvm-request-c-wrappers), \
+                convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf, \
+                convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, \
+                convert-func-to-llvm, reconcile-unrealized-casts)" |
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o forward_buddy_vectorization.ll
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} forward_buddy_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/forward_buddy_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/forward.mlir
   COMMENT "Building forward_buddy_vectorization.o"
-  VERBATIM)
+  VERBATIM
+)
 
 add_custom_command(
   OUTPUT subgraph0_buddy_vectorization.o
@@ -114,7 +119,7 @@ add_custom_command(
     cat ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir |
     sed -e {s/@subgraph0/@subgraph0_buddy_vectorization/} |
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
-    -pass-pipeline "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith))" |
+      -pass-pipeline "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith))" |
     ${LLVM_MLIR_BINARY_DIR}/mlir-opt 
       -test-linalg-transform-patterns=${PATTERN_ARG} |
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt
@@ -146,10 +151,10 @@ add_custom_command(
       -convert-math-to-libm 
       -convert-func-to-llvm
       -reconcile-unrealized-casts |
-    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-    ${LLVM_MLIR_BINARY_DIR}/llc -O3
-      -mtriple=${BUDDY_OPT_TRIPLE} -mattr=${BUDDY_OPT_ATTR} -filetype=obj
-      -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_buddy_vectorization.o
+    ${LLVM_MLIR_BINARY_DIR}/mlir-translate -mlir-to-llvmir -o subgraph0_buddy_vectorization.ll
+  COMMAND
+    ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subgraph0_buddy_vectorization.ll
+      -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_buddy_vectorization.o
   DEPENDS
     ${CMAKE_CURRENT_SOURCE_DIR}/subgraph0.mlir
     ${BUDDY_MLIR_BINARY_DIR}/buddy-opt

--- a/benchmarks/DeepLearning/Ops/ArithAddfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/ArithAddfOp/CMakeLists.txt
@@ -1,3 +1,5 @@
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 # Add custom commands for scalar implementation of arith.addf
 add_custom_command(OUTPUT addf_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/ArithAddfOp/ArithAddf.mlir |
@@ -11,10 +13,9 @@ add_custom_command(OUTPUT addf_scalar.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O0 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/ArithAddfOp/addf_scalar.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o addf_scalar.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} addf_scalar.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/addf_scalar.o
 )
 add_library(ArithAddfScalar STATIC addf_scalar.o)
 set_target_properties(ArithAddfScalar PROPERTIES LINKER_LANGUAGE CXX)
@@ -32,10 +33,9 @@ add_custom_command(OUTPUT addf_auto_vectorization.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/ArithAddfOp/addf_auto_vectorization.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o addf_auto_vectorization.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} addf_auto_vectorization.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/addf_auto_vectorization.o
 )
 add_library(ArithAddfAutoVectorization STATIC addf_auto_vectorization.o)
 set_target_properties(ArithAddfAutoVectorization PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/Ops/ArithDivfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/ArithDivfOp/CMakeLists.txt
@@ -1,3 +1,5 @@
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 # Add custom commands for scalar implementation of arith.divf
 add_custom_command(OUTPUT divf_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/ArithDivfOp/ArithDivf.mlir |
@@ -11,10 +13,9 @@ add_custom_command(OUTPUT divf_scalar.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O0 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/ArithDivfOp/divf_scalar.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o divf_scalar.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} divf_scalar.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/divf_scalar.o
 )
 add_library(ArithDivfScalar STATIC divf_scalar.o)
 set_target_properties(ArithDivfScalar PROPERTIES LINKER_LANGUAGE CXX)
@@ -32,10 +33,9 @@ add_custom_command(OUTPUT divf_auto_vectorization.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/ArithDivfOp/divf_auto_vectorization.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o divf_auto_vectorization.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} divf_auto_vectorization.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/divf_auto_vectorization.o
 )
 add_library(ArithDivfAutoVectorization STATIC divf_auto_vectorization.o)
 set_target_properties(ArithDivfAutoVectorization PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/Ops/ArithMulfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/ArithMulfOp/CMakeLists.txt
@@ -1,3 +1,5 @@
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 # Add custom commands for scalar implementation of arith.mulf
 add_custom_command(OUTPUT mulf_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/ArithMulfOp/ArithMulf.mlir |
@@ -11,10 +13,9 @@ add_custom_command(OUTPUT mulf_scalar.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O0 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/ArithMulfOp/mulf_scalar.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o mulf_scalar.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} mulf_scalar.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/mulf_scalar.o
 )
 add_library(ArithMulfScalar STATIC mulf_scalar.o)
 set_target_properties(ArithMulfScalar PROPERTIES LINKER_LANGUAGE CXX)
@@ -32,10 +33,9 @@ add_custom_command(OUTPUT mulf_auto_vectorization.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/ArithMulfOp/mulf_auto_vectorization.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o mulf_auto_vectorization.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} mulf_auto_vectorization.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/mulf_auto_vectorization.o
 )
 add_library(ArithMulfAutoVectorization STATIC mulf_auto_vectorization.o)
 set_target_properties(ArithMulfAutoVectorization PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/Ops/ArithNegfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/ArithNegfOp/CMakeLists.txt
@@ -1,3 +1,5 @@
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 # Add custom commands for scalar implementation of arith.negf
 add_custom_command(OUTPUT negf_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/ArithNegfOp/ArithNegf.mlir |
@@ -11,10 +13,9 @@ add_custom_command(OUTPUT negf_scalar.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O0 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/ArithNegfOp/negf_scalar.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o negf_scalar.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} negf_scalar.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/negf_scalar.o
 )
 add_library(ArithNegfScalar STATIC negf_scalar.o)
 set_target_properties(ArithNegfScalar PROPERTIES LINKER_LANGUAGE CXX)
@@ -32,10 +33,9 @@ add_custom_command(OUTPUT negf_auto_vectorization.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/ArithNegfOp/negf_auto_vectorization.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o negf_auto_vectorization.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} negf_auto_vectorization.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/negf_auto_vectorization.o
 )
 add_library(ArithNegfAutoVectorization STATIC negf_auto_vectorization.o)
 set_target_properties(ArithNegfAutoVectorization PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/Ops/ArithSubfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/ArithSubfOp/CMakeLists.txt
@@ -1,3 +1,4 @@
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
 
 # Add custom commands for scalar implementation of arith.subf
 add_custom_command(OUTPUT subf_scalar.o
@@ -12,10 +13,9 @@ add_custom_command(OUTPUT subf_scalar.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O0 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/ArithSubfOp/subf_scalar.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o subf_scalar.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} subf_scalar.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subf_scalar.o
 )
 add_library(ArithSubfScalar STATIC subf_scalar.o)
 set_target_properties(ArithSubfScalar PROPERTIES LINKER_LANGUAGE CXX)
@@ -33,10 +33,9 @@ add_custom_command(OUTPUT subf_auto_vectorization.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/ArithSubfOp/subf_auto_vectorization.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o subf_auto_vectorization.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} subf_auto_vectorization.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/subf_auto_vectorization.o
 )
 add_library(ArithSubfAutoVectorization STATIC subf_auto_vectorization.o)
 set_target_properties(ArithSubfAutoVectorization PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/Ops/Conv2DNchwFchwOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/Conv2DNchwFchwOp/CMakeLists.txt
@@ -1,46 +1,46 @@
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 add_custom_command(OUTPUT conv2d_nchw_fchw-scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/Conv2DNchwFchwOp/Conv2DNchwFchw.mlir |
-  sed 's/@conv_2d_nchw_fchw/@conv_2d_nchw_fchw_scalar/' |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-  -convert-linalg-to-loops
-  -convert-scf-to-cf
-  -lower-affine
-  -convert-vector-to-llvm
-  --finalize-memref-to-llvm
-  --llvm-request-c-wrappers
-  -convert-func-to-llvm
-  -reconcile-unrealized-casts |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-  ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple=${BUDDY_OPT_TRIPLE}
-  -mattr=${BUDDY_OPT_ATTR} --filetype=obj
-  -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/Conv2DNchwFchwOp/conv2d_nchw_fchw-scalar.o
+          sed 's/@conv_2d_nchw_fchw/@conv_2d_nchw_fchw_scalar/' |
+          ${LLVM_MLIR_BINARY_DIR}/mlir-opt
+            -convert-linalg-to-loops
+            -convert-scf-to-cf
+            -lower-affine
+            -convert-vector-to-llvm
+            --finalize-memref-to-llvm
+            --llvm-request-c-wrappers
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o conv2d_nchw_fchw-scalar.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} conv2d_nchw_fchw-scalar.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/conv2d_nchw_fchw-scalar.o
 )
 add_library(Conv2DNchwFchwScalar STATIC conv2d_nchw_fchw-scalar.o)
 set_target_properties(Conv2DNchwFchwScalar PROPERTIES LINKER_LANGUAGE CXX)
 
 add_custom_command(OUTPUT conv2d_nchw_fchw_im2col.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/Conv2DNchwFchwOp/conv2d-nchw-fchw-im2col.mlir |
-  sed 's/@conv2d_nchw_fchw_im2col/@conv_2d_nchw_fchw_im2col/' |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-opt
-  -lower-affine
-  -convert-linalg-to-loops
-  -convert-vector-to-scf
-  -convert-scf-to-cf
-  -expand-strided-metadata
-  -lower-affine
-  -convert-vector-to-llvm
-  -memref-expand
-  -arith-expand
-  -convert-arith-to-llvm
-  -finalize-memref-to-llvm
-  -convert-math-to-llvm
-  --llvm-request-c-wrappers
-  -convert-func-to-llvm
-  -reconcile-unrealized-casts |
-  ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-  ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple=${BUDDY_OPT_TRIPLE}
-  -mattr=${BUDDY_OPT_ATTR} --filetype=obj
-  -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/Conv2DNchwFchwOp/conv2d_nchw_fchw_im2col.o
+          sed 's/@conv2d_nchw_fchw_im2col/@conv_2d_nchw_fchw_im2col/' |
+          ${LLVM_MLIR_BINARY_DIR}/mlir-opt
+            -lower-affine
+            -convert-linalg-to-loops
+            -convert-vector-to-scf
+            -convert-scf-to-cf
+            -expand-strided-metadata
+            -lower-affine
+            -convert-vector-to-llvm
+            -memref-expand
+            -arith-expand
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-math-to-llvm
+            --llvm-request-c-wrappers
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o conv2d_nchw_fchw_im2col.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} conv2d_nchw_fchw_im2col.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/conv2d_nchw_fchw_im2col.o
 )
 add_library(Conv2DNchwFchwIm2col STATIC conv2d_nchw_fchw_im2col.o)
 set_target_properties(Conv2DNchwFchwIm2col PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/Ops/Conv2DNhwcHwcfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/Conv2DNhwcHwcfOp/CMakeLists.txt
@@ -1,9 +1,4 @@
-if (CROSS_COMPILE_RVV)
-  set(RISCV_GNU_TOOLCHAIN ${BUDDY_MLIR_BUILD_DIR}/thirdparty/riscv-gnu-toolchain)
-  set(RISCV_GNU_TOOLCHAIN_SYSROOT ${RISCV_GNU_TOOLCHAIN}/sysroot)
-  set(BUDDY_OPT_TRIPLE riscv64)
-  set(BUDDY_OPT_ATTR +v,+m)
-endif()
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
 
 add_custom_command(OUTPUT conv2d_nhwc_hwcf_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/Conv2DNhwcHwcfOp/Conv2DNhwcHwcf.mlir |
@@ -16,10 +11,9 @@ add_custom_command(OUTPUT conv2d_nhwc_hwcf_scalar.o
             -llvm-request-c-wrappers
             -convert-func-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O0 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-	          -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/Conv2DNhwcHwcfOp/conv2d_nhwc_hwcf_scalar.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o conv2d_nhwc_hwcf_scalar.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} conv2d_nhwc_hwcf_scalar.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/conv2d_nhwc_hwcf_scalar.o
 )
 add_library(Conv2DNhwcHwcfScalar STATIC conv2d_nhwc_hwcf_scalar.o)
 set_target_properties(Conv2DNhwcHwcfScalar PROPERTIES LINKER_LANGUAGE CXX)
@@ -35,17 +29,16 @@ add_custom_command(OUTPUT conv2d_nhwc_hwcf_auto_vectorization.o
             -llvm-request-c-wrappers
             -convert-func-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-	          -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/Conv2DNhwcHwcfOp/conv2d_nhwc_hwcf_auto_vectorization.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o conv2d_nhwc_hwcf_auto_vectorization.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} conv2d_nhwc_hwcf_auto_vectorization.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/conv2d_nhwc_hwcf_auto_vectorization.o
 )
 add_library(Conv2DNhwcHwcfAutoVectorization STATIC conv2d_nhwc_hwcf_auto_vectorization.o)
 set_target_properties(Conv2DNhwcHwcfAutoVectorization PROPERTIES LINKER_LANGUAGE CXX)
 
 add_executable(dl-op-linalg-conv2d-nhwc-hwcf-benchmark
   GoogleBenchmarkMain.cpp
-  )
+)
 
 set_target_properties(dl-op-linalg-conv2d-nhwc-hwcf-benchmark PROPERTIES
   LINK_FLAGS "-static"
@@ -57,4 +50,4 @@ target_link_libraries(dl-op-linalg-conv2d-nhwc-hwcf-benchmark
   ${BenchmarkTool}
   Conv2DNhwcHwcfScalar
   Conv2DNhwcHwcfAutoVectorization
-  )
+)

--- a/benchmarks/DeepLearning/Ops/MathExpOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/MathExpOp/CMakeLists.txt
@@ -1,3 +1,5 @@
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 # Add custom commands for scalar implementation of math.exp
 add_custom_command(OUTPUT exp_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/MathExpOp/MathExp.mlir |
@@ -11,10 +13,9 @@ add_custom_command(OUTPUT exp_scalar.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O0 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/MathExpOp/exp_scalar.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o exp_scalar.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} exp_scalar.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/exp_scalar.o
 )
 add_library(MathExpScalar STATIC exp_scalar.o)
 set_target_properties(MathExpScalar PROPERTIES LINKER_LANGUAGE CXX)
@@ -32,10 +33,9 @@ add_custom_command(OUTPUT exp_auto_vectorization.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/MathExpOp/exp_auto_vectorization.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o exp_auto_vectorization.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} exp_auto_vectorization.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/exp_auto_vectorization.o
 )
 add_library(MathExpAutoVectorization STATIC exp_auto_vectorization.o)
 set_target_properties(MathExpAutoVectorization PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/Ops/MathFpowOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/MathFpowOp/CMakeLists.txt
@@ -1,3 +1,5 @@
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 # Add custom commands for scalar implementation of math.fpow
 add_custom_command(OUTPUT fpow_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/MathFpowOp/MathFpow.mlir |
@@ -11,10 +13,9 @@ add_custom_command(OUTPUT fpow_scalar.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O0 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/MathFpowOp/fpow_scalar.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o fpow_scalar.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} fpow_scalar.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/fpow_scalar.o
 )
 add_library(MathFpowScalar STATIC fpow_scalar.o)
 set_target_properties(MathFpowScalar PROPERTIES LINKER_LANGUAGE CXX)
@@ -32,10 +33,9 @@ add_custom_command(OUTPUT fpow_auto_vectorization.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/MathFpowOp/fpow_auto_vectorization.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o fpow_auto_vectorization.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} fpow_auto_vectorization.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/fpow_auto_vectorization.o
 )
 add_library(MathFpowAutoVectorization STATIC fpow_auto_vectorization.o)
 set_target_properties(MathFpowAutoVectorization PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/Ops/MathRsqrtOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/MathRsqrtOp/CMakeLists.txt
@@ -1,3 +1,5 @@
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 # Add custom commands for scalar implementation of math.rsqrt
 add_custom_command(OUTPUT rsqrt_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/MathRsqrtOp/MathRsqrt.mlir |
@@ -11,10 +13,9 @@ add_custom_command(OUTPUT rsqrt_scalar.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O0 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/MathRsqrtOp/rsqrt_scalar.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o rsqrt_scalar.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} rsqrt_scalar.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/rsqrt_scalar.o
 )
 add_library(MathRsqrtScalar STATIC rsqrt_scalar.o)
 set_target_properties(MathRsqrtScalar PROPERTIES LINKER_LANGUAGE CXX)
@@ -32,10 +33,9 @@ add_custom_command(OUTPUT rsqrt_auto_vectorization.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/MathRsqrtOp/rsqrt_auto_vectorization.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o rsqrt_auto_vectorization.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} rsqrt_auto_vectorization.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/rsqrt_auto_vectorization.o
 )
 add_library(MathRsqrtAutoVectorization STATIC rsqrt_auto_vectorization.o)
 set_target_properties(MathRsqrtAutoVectorization PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/Ops/PoolingNhwcSumOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/PoolingNhwcSumOp/CMakeLists.txt
@@ -1,3 +1,5 @@
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 add_custom_command(OUTPUT pooling_nhwc_sum_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/PoolingNhwcSumOp/PoolingNhwcSum.mlir |
           sed 's/@pooling_nhwc_sum/@pooling_nhwc_sum_scalar/' |
@@ -9,10 +11,9 @@ add_custom_command(OUTPUT pooling_nhwc_sum_scalar.o
             -llvm-request-c-wrappers
             -convert-func-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O0 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-	          -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/PoolingNhwcSumOp/pooling_nhwc_sum_scalar.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o pooling_nhwc_sum_scalar.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} pooling_nhwc_sum_scalar.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/pooling_nhwc_sum_scalar.o
 )
 add_library(PoolingNhwcSumScalar STATIC pooling_nhwc_sum_scalar.o)
 set_target_properties(PoolingNhwcSumScalar PROPERTIES LINKER_LANGUAGE CXX)
@@ -28,17 +29,16 @@ add_custom_command(OUTPUT pooling_nhwc_sum_auto_vectorization.o
             -llvm-request-c-wrappers
             -convert-func-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-	          -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/PoolingNhwcSumOp/pooling_nhwc_sum_auto_vectorization.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o pooling_nhwc_sum_auto_vectorization.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} pooling_nhwc_sum_auto_vectorization.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/pooling_nhwc_sum_auto_vectorization.o
 )
 add_library(PoolingNhwcSumAutoVectorization STATIC pooling_nhwc_sum_auto_vectorization.o)
 set_target_properties(PoolingNhwcSumAutoVectorization PROPERTIES LINKER_LANGUAGE CXX)
 
 add_executable(dl-op-linalg-pooling-nhwc-sum-benchmark
   GoogleBenchmarkMain.cpp
-  )
+)
 
 set_target_properties(dl-op-linalg-pooling-nhwc-sum-benchmark PROPERTIES
   LINK_FLAGS "-static"
@@ -50,4 +50,4 @@ target_link_libraries(dl-op-linalg-pooling-nhwc-sum-benchmark
   ${BenchmarkTool}
   PoolingNhwcSumScalar
   PoolingNhwcSumAutoVectorization
-  )
+)

--- a/benchmarks/DeepLearning/Ops/ReduceAddfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/ReduceAddfOp/CMakeLists.txt
@@ -1,3 +1,5 @@
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 # Add custom commands for scalar implementation of reduce.addf
 add_custom_command(OUTPUT addf_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/ReduceAddfOp/ReduceAddf.mlir |
@@ -11,10 +13,9 @@ add_custom_command(OUTPUT addf_scalar.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O0 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/ReduceAddfOp/addf_scalar.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o addf_scalar.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} addf_scalar.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/addf_scalar.o
 )
 add_library(ReduceAddfScalar STATIC addf_scalar.o)
 set_target_properties(ReduceAddfScalar PROPERTIES LINKER_LANGUAGE CXX)
@@ -32,10 +33,9 @@ add_custom_command(OUTPUT addf_auto_vectorization.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/ReduceAddfOp/addf_auto_vectorization.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o addf_auto_vectorization.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} addf_auto_vectorization.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/addf_auto_vectorization.o
 )
 add_library(ReduceAddfAutoVectorization STATIC addf_auto_vectorization.o)
 set_target_properties(ReduceAddfAutoVectorization PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/Ops/ReduceMaxfOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/ReduceMaxfOp/CMakeLists.txt
@@ -1,3 +1,5 @@
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 # Add custom commands for scalar implementation of reduce.maxf
 add_custom_command(OUTPUT maxf_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/ReduceMaxfOp/ReduceMaxf.mlir |
@@ -11,10 +13,9 @@ add_custom_command(OUTPUT maxf_scalar.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O0 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/ReduceMaxfOp/maxf_scalar.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o maxf_scalar.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} maxf_scalar.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/maxf_scalar.o
 )
 add_library(ReduceMaxfScalar STATIC maxf_scalar.o)
 set_target_properties(ReduceMaxfScalar PROPERTIES LINKER_LANGUAGE CXX)
@@ -32,10 +33,9 @@ add_custom_command(OUTPUT maxf_auto_vectorization.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/ReduceMaxfOp/maxf_auto_vectorization.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o maxf_auto_vectorization.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} maxf_auto_vectorization.ll
+            -c -save-temps -o ${CMAKE_CURRENT_BINARY_DIR}/maxf_auto_vectorization.o
 )
 add_library(ReduceMaxfAutoVectorization STATIC maxf_auto_vectorization.o)
 set_target_properties(ReduceMaxfAutoVectorization PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/Ops/SoftmaxExpSumDivOp/CMakeLists.txt
+++ b/benchmarks/DeepLearning/Ops/SoftmaxExpSumDivOp/CMakeLists.txt
@@ -1,3 +1,5 @@
+separate_arguments(CLANG_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
 add_custom_command(OUTPUT softmaxexpsumdiv_scalar.o
   COMMAND cat ${BUDDY_SOURCE_DIR}/benchmarks/DeepLearning/Ops/SoftmaxExpSumDivOp/SoftmaxExpSumDiv.mlir |
           sed 's/@softmaxexpsumdiv/@softmaxexpsumdiv_scalar/' |
@@ -10,10 +12,9 @@ add_custom_command(OUTPUT softmaxexpsumdiv_scalar.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O0 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/SoftmaxExpSumDivOp/softmaxexpsumdiv_scalar.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o softmaxexpsumdiv_scalar.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O0 ${CLANG_FLAGS_LIST} softmaxexpsumdiv_scalar.ll
+            -c -save-temps -o softmaxexpsumdiv_scalar.o
 )
 add_library(SoftmaxExpSumDivScalar STATIC softmaxexpsumdiv_scalar.o)
 set_target_properties(SoftmaxExpSumDivScalar PROPERTIES LINKER_LANGUAGE CXX)
@@ -30,10 +31,9 @@ add_custom_command(OUTPUT softmaxexpsumdiv_auto_vectorization.o
             -convert-func-to-llvm
             -convert-math-to-llvm
             -reconcile-unrealized-casts | 
-          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_MLIR_BINARY_DIR}/llc -O3 -mtriple=${BUDDY_OPT_TRIPLE} 
-            -mattr=${BUDDY_OPT_ATTR} --filetype=obj 
-            -o ${BUDDY_BINARY_DIR}/../benchmarks/DeepLearning/Ops/SoftmaxExpSumDivOp/softmaxexpsumdiv_auto_vectorization.o
+          ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir -o softmaxexpsumdiv_auto_vectorization.ll
+  COMMAND ${LLVM_MLIR_BINARY_DIR}/clang -O3 ${CLANG_FLAGS_LIST} softmaxexpsumdiv_auto_vectorization.ll
+            -c -save-temps -o softmaxexpsumdiv_auto_vectorization.o
 )
 add_library(SoftmaxExpSumDivAutoVectorization STATIC softmaxexpsumdiv_auto_vectorization.o)
 set_target_properties(SoftmaxExpSumDivAutoVectorization PROPERTIES LINKER_LANGUAGE CXX)

--- a/benchmarks/DeepLearning/README.md
+++ b/benchmarks/DeepLearning/README.md
@@ -131,7 +131,8 @@ $ cmake -G Ninja .. \
     -DCMAKE_C_FLAGS="-march=rv64gcv --target=riscv64-unknown-linux-gnu --sysroot=${RISCV_GNU_TOOLCHAIN}/sysroot --gcc-toolchain=${RISCV_GNU_TOOLCHAIN} -fPIC" \
     -DCMAKE_CXX_FLAGS="-march=rv64gcv --target=riscv64-unknown-linux-gnu --sysroot=${RISCV_GNU_TOOLCHAIN}/sysroot --gcc-toolchain=${RISCV_GNU_TOOLCHAIN} -fPIC" \
     -DBUDDY_MLIR_BUILD_DIR=${BUDDY_MLIR_BUILD_DIR} \
-    -DBUDDY_MLIR_BUILD_CROSS_DIR=${BUDDY_MLIR_BUILD_CROSS_DIR}
+    -DBUDDY_MLIR_BUILD_CROSS_DIR=${BUDDY_MLIR_BUILD_CROSS_DIR} \
+    -DBUDDY_MLIR_CROSS_LIB_DIR=${BUDDY_MLIR_BUILD_CROSS_DIR}/lib
 
 $ ninja <target benchmark>
 // For example: 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 --pre --extra-index-url https://download.pytorch.org/whl/cpu
-torch == 2.1.2
+torch == 2.5.1
 numpy < 2
-transformers == 4.33.1
-tokenizers == 0.13.3
-sentencepiece == 0.1.99
+transformers == 4.46.2
+tokenizers >= 0.20
+sentencepiece == 0.2.0
 accelerate
 protobuf
 pybind11 == 2.11.1


### PR DESCRIPTION
This PR upgrades the python requirements to sync with buddy-mlir, and replaces `llc` with `clang` when compiling `*.ll` files. Several changes are made to build the benchmarks:

1. Expand self-attention layer instead of using `nn.MultiheadAttention`.
2. Update LeNet, MobileNet and ResNet to be the same as examples in buddy-mlir.
3. Remove int64 type parameters in ResNet and MobileNet.
4. Add `convert-elementwise-to-linalg` pass to fix bufferization and lower TinyLlama.
5. Update `DeepLearning/README.md` and add missing `BUDDY_MLIR_CROSS_LIB_DIR` macro for cross compilation.
